### PR TITLE
fix for #7 in V.pre1.0

### DIFF
--- a/jquery.jstree.js
+++ b/jquery.jstree.js
@@ -2819,10 +2819,7 @@
 						}
 					});
 				});
-				if(!ts) {
-					if(obj.length === 1 && obj.is("li")) { this._repair_state(obj); }
-					if(obj.is("li")) { obj.each(function () { _this._repair_state(this); }); }
-					else { obj.find("> ul > li").each(function () { _this._repair_state(this); }); }
+				if(!ts) {					
 					obj.find(".jstree-checked").parent().parent().each(function () { _this._repair_state(this); }); 
 				}
 			},


### PR DESCRIPTION
Hi Ivan,

I hit the same bug #7  ("Just the first two levels of the tree with checkboxes are checked correctly") in jstree with the checkbox plugin and found the following solution to fix it. Maybe you can include it in a RC4 release before the 1.0 release. 

Thanks for your great work!
