### PR TITLE
Fix $.jstree.__destruct so that recreating a tree would work correcty

### DIFF
--- a/jstree.core.js
+++ b/jstree.core.js
@@ -122,7 +122,7 @@ Some static functions and variables, unless you know exactly what you are doing 
 		__destruct	: function (instance) {
 			instance = $.jstree._reference(instance);
 			if(!instance) { return false; }
-			var s = instance._get_settings(),
+			var s = instance.get_settings(),
 				n = instance.get_index(),
 				i = 0;
 			if(focused_instance === n) {
@@ -137,7 +137,7 @@ Some static functions and variables, unless you know exactly what you are doing 
 			$.each(s.plugins, function (i, val) {
 				try { plugins[val].__destruct.apply(instance); } catch(err) { }
 			});
-			this.__trigger("__destruct");
+			instance.__trigger("__destruct");
 			instance.get_container()
 				.unbind(".jstree")
 				.undelegate(".jstree")


### PR DESCRIPTION
When I was using jstree in my project, I realized that it fails to recreate the tree if I call the jstree function on the same container multiple times.  When I investigated this issue, I realized that this is happening because of two errors in the __destruct function.  This commit fixes those errors.
