### PR TITLE
Fixed error which caused double selection of nodes after refreshing with ui plugin on

### DIFF
--- a/jquery.jstree.js
+++ b/jquery.jstree.js
@@ -1088,7 +1088,7 @@
 			save_selected : function () {
 				var _this = this;
 				this.data.ui.to_select = [];
-				this.data.ui.selected.each(function () { if(this.id) { _this.data.ui.to_select.push("#" + this.id.toString().replace(/^#/,"").replace(/\\\//g,"/").replace(/\//g,"\\\/").replace(/\\\./g,".").replace(/\./g,"\\.").replace(/\:/g,"\\:")); } });
+				this.data.ui.selected.each(function () { if(!this.id) { _this.data.ui.to_select.push("#" + this.id.toString().replace(/^#/,"").replace(/\\\//g,"/").replace(/\//g,"\\\/").replace(/\\\./g,".").replace(/\./g,"\\.").replace(/\:/g,"\\:")); } });
 				this.__callback(this.data.ui.to_select);
 			},
 			reselect : function () {


### PR DESCRIPTION
When ui plugin is on, then calling jstree('refresh') caused adding again the same nodes to list of selected nodes, and the result was, that calling jstree('get_selected') after refresh returns list with doubled number of nodes (or trippled, etc., after next refreshes), and each node was added twice (tripple, etc.) to the list.
