### PR TITLE
remove //*/ which gets interpreted as a block comment when concatenating ...

### DIFF
--- a/jstree.core.js
+++ b/jstree.core.js
@@ -1886,6 +1886,4 @@ Some static functions and variables, unless you know exactly what you are doing 
 		$.vakata.css.add_sheet({ str : css_string, title : "jstree" });
 	});
 })(jQuery);
-//*/
-
 })();

--- a/jstree.themes.js
+++ b/jstree.themes.js
@@ -212,4 +212,3 @@ Controls the looks of jstree, without this plugin you will get a functional tree
 	// include the themes plugin by default
 	$.jstree.defaults.plugins.push("themes");
 })(jQuery);
-//*/

--- a/jstree.unique.js
+++ b/jstree.unique.js
@@ -30,4 +30,3 @@ Does not allow the same name amongst siblings (still a bit experimental).
 	// include the unique plugin by default
 	$.jstree.defaults.plugins.push("unique");
 })(jQuery);
-//*/

--- a/jstree.xml.js
+++ b/jstree.xml.js
@@ -182,4 +182,3 @@ This plugin makes it possible for jstree to use XML data sources.
 	// include the html plugin by default
 	$.jstree.defaults.plugins.push("xml");
 })(jQuery);
-//*/


### PR DESCRIPTION
...the jstree files together.

some files have a //*/ as the last line in the file with no new line at the end

So when concatenating the js files :

File1.js end:
//*/

File2.js beginning:
/*\* 
A block comment from the next file.
*/

concat.js:
//_//_\* 
A block comment from the next file.
*/

As a result in concat.js, "A block comment from the next file."

becomes javascript code.
