### PR TITLE
Correcting Context menu new node bug

### DIFF
--- a/jstree.contextmenu.js
+++ b/jstree.contextmenu.js
@@ -35,9 +35,9 @@ Enables a rightclick contextmenu.
 						"label"				: "Create",
 						"action"			: function (data) { 
 							var inst = $.jstree._reference(data.reference),
-								obj = inst.get_node(data.reference);
-							inst.create_node(obj);
-							inst.edit(obj);
+								obj = inst.get_node(data.reference),
+								new_node = inst.create_node(obj);
+							inst.edit(new_node);
 						}
 					},
 					"rename" : {


### PR DESCRIPTION
When we create a new node using Context menu plugin, the plugin will edit the old node.
This quick fix permit to rename the new node.
