### PR TITLE
Fixed incorrect checkbox when the data is retrieved through Ajax

### DIFF
--- a/src/jstree.checkbox.js
+++ b/src/jstree.checkbox.js
@@ -69,6 +69,8 @@ Adds checkboxes to the tree.
 					obj.each($.proxy(function (i, d) { 
 						this.checkbox_repair($(d));
 					}, this));
+					
+					return;
 				}
 
 				var c = obj.find(' > a > .jstree-checkbox'),


### PR DESCRIPTION
When the data is retrieved through Ajax, checkbox checked incorrect.

For example:

<pre>
<code>
&lt;script&gt;
$(function(){
    $('#demo1').jstree({
        "plugins" : ['checkbox','themes', 'json'],
        'json': {
            'ajax': {
                'url': '/jstree/get.php',
                'data': function (n) {
                    return { id : n.attr ? n.attr("id") : 0 };
                }
            }
        }
    });
});
&lt;/script&gt;
</code>
</pre>


<pre>
<code>
&lt;div id="demo1" class="demo" style="min-height:100px;"&gt;&lt;/div&gt;
</code>
</pre>


<pre>
<code>
&lt;?php
echo json_encode(array(
    array(
        'li_attr' => array('id'=>'jstree_1'),
        'title' => 'Node 1',
        'children' => array(), 
        'data' => array(
                    'jstree' => 
                        array('checkbox' => 
                            array(
                                'name' => 'categoryIds[]',
                                'checked' => true,
                                'value' => "1",
                            )
                        )
                )
    ),
    array(
        'li_attr' => array('id'=>'jstree_2'),
        'title' => 'Node 2',
        'data' => array(
                    'jstree' => 
                        array('checkbox' => 
                            array(
                                'name' => 'categoryIds[]',
                                'checked' => false,
                                'value' => "2",
                            )
                        )
                )
    )
));
</code>
</pre>


Both node checked=true. But expected node 2 unchecked
