### PR TITLE
Adding support for corrupted cookies

### DIFF
--- a/jquery.jstree.js
+++ b/jquery.jstree.js
@@ -2072,7 +2072,7 @@
 			}
 			if(!!s.save_selected) {
 				tmp = $.cookie(s.save_selected);
-				if(tmp && tmp.length && this.data.ui) { this.data.ui.to_select = tmp.split(","); }
+				if(tmp && tmp.length && this.data.ui && !!this._get_node(tmp)) { this.data.ui.to_select = tmp.split(","); }
 			}
 			this.get_container()
 				.one( ( this.data.ui ? "reselect" : "reopen" ) + ".jstree", $.proxy(function () {


### PR DESCRIPTION
If the saved node id is not existing in the currently loaded tree, nothing is "initially_selected". We don't override the initially selected node if the save_selected node don't exist anymore
