### PR TITLE
Added missing grunt-contrib-qunit from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dox": "~0.4.4",
     "grunt-contrib-less": "~0.8.2",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-contrib-imagemin": "~0.4.0"
+    "grunt-contrib-imagemin": "~0.4.0",
+    "grunt-contrib-qunit": "~v0.3.0"
   }
 }


### PR DESCRIPTION
When doing `npm install grunt` on a fresh clone it complained about missing grunt-contrib-qunit and wouldn't run grunt. Adding the requirement fixed the grunt call.
