### PR TITLE
Bugfix IE 11 activeXObject detection

### DIFF
--- a/jquery.jstree.js
+++ b/jquery.jstree.js
@@ -2997,7 +2997,7 @@
 	$.vakata.xslt = function (xml, xsl, callback) {
 		var r = false, p, q, s;
 		// IE9
-		if(r === false && window.ActiveXObject) {
+		if(r === false && (window.ActiveXObject || "ActiveXObject" in window)) {
 			try {
 				r = new ActiveXObject("Msxml2.XSLTemplate");
 				q = new ActiveXObject("Msxml2.DOMDocument");


### PR DESCRIPTION
The script was not working in IE 11 when using XML as data source. This solved my problem.
