### PR TITLE
Support a base icon url prefix

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1662,7 +1662,9 @@
 					node.childNodes[1].childNodes[0].className += ' ' + obj.icon + ' jstree-themeicon-custom';
 				}
 				else {
-					node.childNodes[1].childNodes[0].style.backgroundImage = 'url('+obj.icon+')';
+					// ensure that the option is a string before using it when building to the background url
+					var base_icons_url = this.settings.core.themes.iconsurl ? this.settings.core.themes.iconsurl : "";
+					node.childNodes[1].childNodes[0].style.backgroundImage = 'url(' + base_icons_url + obj.icon + ')';
 					node.childNodes[1].childNodes[0].style.backgroundPosition = 'center center';
 					node.childNodes[1].childNodes[0].style.backgroundSize = 'auto';
 					node.childNodes[1].childNodes[0].className += ' jstree-themeicon-custom';


### PR DESCRIPTION
I use data attribute to set my icons, in the form data-jstree='{"icon":"http://jstree.com/tree.png"}'. Unfortunately the real url is by far much longer, and on a tree of more than 10000 items it causes excessive overhead in the page generation time and while transferring the html to the browser.
This pull request introduces an additional optional parameter to be used during the jstree instantiation:

"core" : {
  "themes" : {
    "iconsurl" : "../long/long/base/url/images/"
  }
}

It is backward compatible: when the parameter iconsurl is unset, jstree simply works as usual.
