### PR TITLE
context menu label now can be string or function

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For a complete list of configuration options, events and available functions ref
 [demo]: http://jstree.com/demo
 
 ## Contributing
-In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [grunt](https://github.com/cowboy/grunt).
+In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [grunt](https://github.com/gruntjs/grunt).
 
 _Please do NOT edit files in the "dist" subdirectory as they are generated via grunt. You'll find source code in the "src" subdirectory!_
 

--- a/src/jstree.contextmenu.js
+++ b/src/jstree.contextmenu.js
@@ -319,6 +319,12 @@
 							}
 						}) : false;
 			},
+			_getLabel : function(o) {
+				if (o && $.isFunction(o.label))
+					return o.label();
+				else
+					return = o.label;
+			},
 			_parse : function (o, is_callback) {
 				if(!o) { return false; }
 				if(!is_callback) {
@@ -347,7 +353,7 @@
 						}
 						str += "><"+"/i><"+"span class='vakata-contextmenu-sep'>&#160;<"+"/span>";
 					}
-					str += val.label + (val.shortcut?' <span class="vakata-contextmenu-shortcut vakata-contextmenu-shortcut-'+val.shortcut+'">'+ (val.shortcut_label || '') +'</span>':'') + "<"+"/a>";
+					str += $.vakata.context._getLabel(val) + (val.shortcut?' <span class="vakata-contextmenu-shortcut vakata-contextmenu-shortcut-'+val.shortcut+'">'+ (val.shortcut_label || '') +'</span>':'') + "<"+"/a>";
 					if(val.submenu) {
 						tmp = $.vakata.context._parse(val.submenu, true);
 						if(tmp) { str += tmp; }

--- a/test/index.html
+++ b/test/index.html
@@ -6,11 +6,11 @@
   <!-- Load local QUnit. -->
   <link rel="stylesheet" href="libs/qunit.css" media="screen">
   <script src="libs/qunit.js"></script>
-  <!-- Load local lib and tests. -->
-  <script src="test.js"></script>
 </head>
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture">this had better work.</div>
+  <!-- Load local lib and tests. -->
+  <script src="test.js"></script>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,23 @@ test('basic test', function() {
   ok(true, 'this had better work.');
 });
 
-
 test('can access the DOM', function() {
   expect(1);
   var fixture = document.getElementById('qunit-fixture');
-  equal(fixture.innerText, 'this had better work.', 'should be able to access the DOM.');
+  equal(fixture.innerText || fixture.textContent, 'this had better work.', 'should be able to access the DOM.');
+});
+
+test('can pass a function or string as label to context menu item using _getLabel', function() {
+  expect(2);
+  var uniqueName = "$%(*$&#&(@dfd";
+  var stringLabelMenu = {
+		label: uniqueName
+  };
+  var funtionLabelMenu = {
+		label: function() { return uniqueName; }
+  };
+  var result = $.vakata.context._getLabel(stringLabelMenu);
+  equal(result, uniqueName, 'this had better work.','_getLabel does not accept funtions.');
+  var result = $.vakata.context._getLabel(funtionLabelMenu);
+  equal(result, uniqueName, 'this had better work.','_getLabel does not accept funtions.');
 });


### PR DESCRIPTION
added a _getLabel helper function to context menu so context menu labels can be extracted using it. now labels can be either a string or a function.
Also fixed some minor issues tests and added a new test for _getLabel() function.
