### PR TITLE
avoid separator at the beginning of the menu

### DIFF
--- a/dist/jstree.js
+++ b/dist/jstree.js
@@ -4294,7 +4294,7 @@
 					vakata_context.items	= [];
 				}
 				var str = "",
-					sep = false,
+					sep = true,
 					tmp;
 
 				if(is_callback) { str += "<"+"ul>"; }


### PR DESCRIPTION
starting with the check variable as true, if the first element of the menu has the separator_before set, it will skip it
