### PR TITLE
Fix for args bug

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -201,7 +201,7 @@
 				method = is_method && instance ? instance[arg] : null;
 			// if calling a method, and method is available - execute on the instance
 			result = is_method && method ?
-				method.apply(instance, args) :
+				method.apply(instance, args[0]) :
 				null;
 			// if there is no instance and no method is being called - create one
 			if(!instance && !is_method && (arg === undefined || $.isPlainObject(arg))) {


### PR DESCRIPTION
I had trouble when I tried renaming a node by calling following method:
$("#jstree").jstree('rename_node', [data.node, 'foo']);
...debugging the code, I found out that second parameter of "rename_node" method (val) was always undefined. I've fix this problem by making a small change.
