### PR TITLE
Fixed bug related to defaults.checkbox.whole_node.

### DIFF
--- a/src/jstree.checkbox.js
+++ b/src/jstree.checkbox.js
@@ -364,7 +364,7 @@
 			return obj;
 		};
 		this.activate_node = function (obj, e) {
-			if(this.settings.checkbox.whole_node || $(e.target).hasClass('jstree-checkbox')) {
+			if(this.settings.core.multiple) {
 				e.ctrlKey = true;
 			}
 			return parent.activate_node.call(this, obj, e);


### PR DESCRIPTION
Not sure what the intention was to inspect whether 'whole_node' was true or the checkbox was checked.  If the answer is to mimic that the user was holding the Ctrl key, I think the question would be is 'multiple' true.
