### PR TITLE
Added redraw_node event

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1800,6 +1800,10 @@
 					this.open_node(obj.id, false, 0);
 				}, this), 0);
 			}
+			
+			//Added to allow for authors to respond to the redraw_node event on a node level
+			this.trigger("redraw_node", { "data": obj, "node": node });
+			
 			return node;
 		},
 		/**


### PR DESCRIPTION
Added the redraw_node event to allow authors to respond to the redraw even on a node level (in case they are handling node construction such as amending the node HTML)
