### PR TITLE
event object not passed to deselect_node

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2609,12 +2609,12 @@
 		 * @param {Boolean} supress_event if set to `true` the `changed.jstree` event won't be triggered
 		 * @trigger deselect_node.jstree, changed.jstree
 		 */
-		deselect_node : function (obj, supress_event, e) {
+		deselect_node : function (obj, supress_event, prevent_close, e) {
 			var t1, t2, dom;
 			if($.isArray(obj)) {
 				obj = obj.slice();
 				for(t1 = 0, t2 = obj.length; t1 < t2; t1++) {
-					this.deselect_node(obj[t1], supress_event, e);
+					this.deselect_node(obj[t1], supress_event, prevent_close, e);
 				}
 				return true;
 			}


### PR DESCRIPTION
I found all of the (internal) callers of deselect_node set the event object as a fourth parameter. I had problems selecting subnodes in my appliction and this is how I fixed it for me.

There may be better ways to do that (f.i. checking the arguments directly) but if you want to include this, here's my take. :-)
