### PR TITLE
Avoid click interception

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -550,7 +550,6 @@
 						this.toggle_node(e.target);
 					}, this))
 				.on("click.jstree", ".jstree-anchor", $.proxy(function (e) {
-						e.preventDefault();
 						$(e.currentTarget).focus();
 						this.activate_node(e.currentTarget, e);
 					}, this))


### PR DESCRIPTION
JSTree shouldn't intercept click event.  

Many users tried to get clickable nodes, but click events are intercepted. We can "easily" get around this problem by listening `changed.jstree` event, as mention in the doc : 

> Clicking on the link however will not direct the user to a new page, to do that - intercept the changed.jstree event and act accordingly.

I think this feature request is too recurrent and should be native.

Plus, I came across a deepest problem : what if you've got **others buttons** in your node ? See this picture/code for an example : 
![2014-06-13_1736](https://cloud.githubusercontent.com/assets/3398490/3271852/9ced07f2-f311-11e3-876b-761bd81dd666.png)

```
<ul>
  <li>Category
    <ul>
      <li>Subcategory
        <ul>
          <li>Hello World
            <div class="actions">
              <a href="/see">see</a>
              <a href="/edit">edit</a>
              <a href="/delete">delete</a>
            </div>
        </li></ul>
    </li></ul>
</li></ul>
```

It starts to be a real headache, so why not simply let this click event alone ?

---

This PR may be refused for a good reason. I tried to search around for it, but I didn't find this reason.
