### PR TITLE
Add support for HTML vs text node loading

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -310,7 +310,7 @@
 		 * Input text is in HTML format
 		 * @name $.jstree.defaults.core.html
 		 */
-		html			: false,
+		html			: true,
 		/**
 		 * configure the various strings used throughout the tree
 		 *
@@ -1653,7 +1653,7 @@
 			tmp.children("ins, i, ul").remove();
 			tmp = tmp.html();
 			tmp = $('<div />').html(tmp);
-			if(this.settings.html) {
+			if(this.settings.core.html) {
 				data.text = tmp.html();
 			} else {
 				data.text = tmp.text();
@@ -2076,7 +2076,7 @@
 				}
 			}
 			//node.childNodes[1].appendChild(d.createTextNode(obj.text));
-			if(this.settings.html) {
+			if(this.settings.core.html) {
 				node.childNodes[1].innerHTML += obj.text;
 			} else {
 				node.childNodes[1].innerHTML += $('<div></div>').text(obj.text).html();


### PR DESCRIPTION
This allows for plain-text node loading as well as the current HTML node loading.

I'm currently shipping with HTML mode defaulting to off. There are a number of reasons for this. You cannot effectively use the "rename node" feature without being careful to avoid and remembering to escape HTML entities which of course no end user would do. Also, unless if you really need HTML mode it's probably not necessary for many use cases.

I haven't committed the distribution versions to keep the patch clean. I've also got a test script (with both a HTML and a text version) which I can commit if desired.
