### PR TITLE
v3.0.2 bug in open_node, fix - revert to 3.0.1 code

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -993,9 +993,12 @@
 		 * @trigger load_node.jstree
 		 */
 		load_node : function (obj, callback) {
-			var k, l, i, j, c;
+			var t1, t2, k, l, i, j, c;
 			if($.isArray(obj)) {
-				this._load_nodes(obj.slice(), callback);
+				obj = obj.slice();
+				for(t1 = 0, t2 = obj.length; t1 < t2; t1++) {
+				this.load_node(obj[t1], callback);
+				}
 				return true;
 			}
 			obj = this.get_node(obj);


### PR DESCRIPTION
after 3.0.1 there is an error 'TypeError: callback is undefined jquery.jstree.js:1070'
If revert this part of code by v3.0.1 code, then it works.
I don't think this is good method, but it works now.

My script is:

```
$(function () {
    var tree = $("#tree").jstree({ 
    "core" : {
        "data" : {
        "url" : function(node) {
        return node.id === "#" ?
        "/services/lk_tree/?first=1&id2=" : "/services/lk_tree/";
        },
        "data" : function (node) {
        return {"id": node.id } ;
        }
        }

        }
    });

    $("#tree").on("select_node.jstree", function(e,data){
    if($("#tree").jstree(true).is_parent(data.selected) == false ){
        window.location.href = data.node.a_attr.href;
} else {
$("#tree").jstree(true).load_node(data.selected);
$("#tree").jstree(true).open_node(data.selected);

};

    });

    $("#tree").on("load_node.jstree", function(e,data){
    if($("#tree").jstree(true).is_leaf(data.node.id) === true ){
        window.location.href = data.node.a_attr.href;
}
        });
});
```
