### PR TITLE
Option to refresh data without remembering previous state

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2941,10 +2941,14 @@
 		 * refreshes the tree - all nodes are reloaded with calls to `load_node`.
 		 * @name refresh()
 		 * @param {Boolean} skip_loading an option to skip showing the loading indicator
+		 * @param {Boolean} forget_state an option to forget state from before reload, state is refreshed from data
 		 * @trigger refresh.jstree
 		 */
-		refresh : function (skip_loading) {
-			this._data.core.state = this.get_state();
+		refresh : function (skip_loading, forget_state) {
+			this._data.core.state = null;
+			if(!forget_state) {
+				this._data.core.state = this.get_state();
+			}
 			this._cnt = 0;
 			this._model.data = {
 				'#' : {


### PR DESCRIPTION
Adding an option on refresh to forget previous state. The state is then refreshed from data source.
