### PR TITLE
Clone array of selected nodes in get_selected method

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2743,7 +2743,7 @@
 		 * @return {Array}
 		 */
 		get_selected : function (full) {
-			return full ? $.map(this._data.core.selected, $.proxy(function (i) { return this.get_node(i); }, this)) : this._data.core.selected;
+			return full ? $.map(this._data.core.selected, $.proxy(function (i) { return this.get_node(i); }, this)) : this._data.core.selected.slice();
 		},
 		/**
 		 * get an array of all top level selected nodes (ignoring children of selected nodes)


### PR DESCRIPTION
Currently, get_selected(true) is called, a new array is returned (so the user is free to edit it), however get_selected(false) returns the same array which is used internally.

Therefore the internal array can be directly edited, causing issues such as not being able to reselect nodes.

This commit just slices the the array before returning it, so a clone of the array is returned.
