### PR TITLE
Fix for "Text is running off the side of folders box for long titles."

### DIFF
--- a/src/themes/base.less
+++ b/src/themes/base.less
@@ -1,7 +1,7 @@
 // base jstree
 .jstree-node, .jstree-children, .jstree-container-ul { display:block; margin:0; padding:0; list-style-type:none; list-style-image:none; }
 .jstree-node { white-space:nowrap; }
-.jstree-anchor { display:inline-block; color:black; white-space:nowrap; padding:0 4px 0 1px; margin:0; vertical-align:top; }
+.jstree-anchor { display:inline-block; color:black; white-space:nowrap; padding:0 4px 0 1px; margin:0; vertical-align:top; width: 90%; overflow: hidden; text-overflow: ellipsis;}
 .jstree-anchor:focus { outline:0; }
 .jstree-anchor, .jstree-anchor:link, .jstree-anchor:visited, .jstree-anchor:hover, .jstree-anchor:active { text-decoration:none; color:inherit; }
 .jstree-icon { display:inline-block; text-decoration:none; margin:0; padding:0; vertical-align:top; text-align:center; }


### PR DESCRIPTION
When you add longer names for folders the text is running off the side.
