### PR TITLE
explicitly call toggle_node on selected node

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2859,6 +2859,7 @@
 					 * @param {Object} event the event (if any) that triggered this changed event
 					 */
 					this.trigger('changed', { 'action' : 'select_node', 'node' : obj, 'selected' : this._data.core.selected, 'event' : e });
+					this.toggle_node(obj);
 				}
 			}
 		},


### PR DESCRIPTION
it's annoying that you have to actually click the little arrow in order to expand and collapse nodes while clicking on the actual node name does nothing. 

currently you have to do the following to accomplish this:

$('.jstree-filebrowser').jstree().on('select_node.jstree', function (e, data) {
    $(this).jstree("toggle_node", data.node);
});

this pull request add in the functionality that people expect when clicking on the node name thus improving over all user experience of the plugin.
