### PR TITLE
Test: set_text is triggered exactly once after save

### DIFF
--- a/test/unit/index.html
+++ b/test/unit/index.html
@@ -6,10 +6,20 @@
   <!-- Load local QUnit. -->
   <link rel="stylesheet" href="libs/qunit.css" media="screen">
   <script src="libs/qunit.js"></script>
+
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+  <script src="./../../src/jstree.js"></script>
+  <link rel="stylesheet" href="./../../src/themes/default/style.css" />
 </head>
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture">this had better work.</div>
+
+  <div id="test">
+    <ul>
+      <li>Node #1</li>
+    </ul>
+  </div>
   <!-- Load local lib and tests. -->
   <script src="test.js"></script>
 </body>

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -1,11 +1,53 @@
+$(function () {
+
 test('basic test', function() {
   expect(1);
   ok(true, 'this had better work.');
 });
 
-
 test('can access the DOM', function() {
   expect(1);
   var fixture = document.getElementById('qunit-fixture');
   equal(fixture.innerText || fixture.textContent, 'this had better work.', 'should be able to access the DOM.');
+});
+
+test('set_text is triggered exactly once after save', function () {
+  expect(1);
+
+  // setup
+  var $elem = $('#test');
+  $elem.jstree({
+    core: {
+      check_callback: $.noop,
+      destroy_callback: $.noop
+    }
+  });
+
+  var instance = $elem.jstree(true);
+
+  // only count triggers cause by blur
+  var countTriggers = false;
+
+  // test
+  $elem.on('set_text.jstree', function(event, data) {
+  	if (countTriggers) {
+      ok(true, 'set_text triggered once.');
+    }
+  });
+
+  instance.create_node(null, 'New node', undefined, function (new_node) {
+    instance.edit(new_node);
+
+    countTriggers = true;
+    $(document.activeElement).trigger('blur');
+    countTriggers = false;
+
+    // teardown
+    instance.delete_node(new_node);
+  });
+
+  // teardown
+  $elem.jstree('destroy', true);
+});
+
 });


### PR DESCRIPTION
Hi, I've noticed that set_text is triggered twice after node name edit, and then blur (and possibly three times if this condition is met https://github.com/vakata/jstree/blob/e2923e840d47eef45358ea9236c2cb6b15bf6e41/dist/jstree.js#L4061).

I cannot offer a solution at the moment, because event triggering is not well separated from associated functions, and some more rewrites would be required, or maybe that's the point, triggering events every time, but anyway I wrote a test to prove this bug.

I see tests has been just started for this project, so this might not be the right way of writing tests for jstree, so please feel free to not merge this pull request and just treat is as a bug report.

(With this test come another bug: jstree instance cannot be destroyed right after initialization because of this timeout: https://github.com/vakata/jstree/blob/e2923e840d47eef45358ea9236c2cb6b15bf6e41/dist/jstree.js#L711, so it would be nice to have tests started anyway,)
