### PR TITLE
Cannot load a node whose id contains ? (question mark) or ` (reverse single quote)

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -88,7 +88,7 @@
 		 */
 		plugins : {},
 		path : src && src.indexOf('/') !== -1 ? src.replace(/\/[^\/]+$/,'') : '',
-		idregex : /[\\:&!^|()\[\]<>@*'+~#";.,=\- \/${}%]/g
+		idregex : /[\\:&!^|()\[\]<>@*'+~#";.,=\- \/${}%?`]/g
 	};
 	/**
 	 * creates a jstree instance


### PR DESCRIPTION
I know these special characters are not valid inside an XML id (DOM element id) but it doesn't hurt to add them to the `idregex`.
