### PR TITLE
Stop destroy calling teardown twice

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -542,7 +542,6 @@
 			}
 			if(!keep_html) { this.element.empty(); }
 			this.element.unbind("destroyed", this.teardown);
-			this.teardown();
 		},
 		/**
 		 * part of the destroying of an instance. Used internally.


### PR DESCRIPTION
Currently if you call destroy it throws a JavaScript error as the teardown functionality is called twice. This stops that from happening.
