### PR TITLE
Update parent after a node moving

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3797,6 +3797,7 @@
 
 				// update object
 				obj.parent = new_par.id;
+				this._model.data[obj.id].parent = new_par.id;
 				tmp = new_par.parents.concat();
 				tmp.unshift(new_par.id);
 				p = obj.parents.length;


### PR DESCRIPTION
When node has been moved the jstree data model has not been updated.
