### PR TITLE
Global `jQuery` object would cause error in browserify env.

### DIFF
--- a/src/vakata-jstree.js
+++ b/src/vakata-jstree.js
@@ -17,11 +17,11 @@
 					c.core[i] = JSON.parse(this.getAttribute(i)) || this.getAttribute(i);
 				}
 			}
-			jQuery(this).jstree(c);
+			$(this).jstree(c);
 		};
 		// proto.attributeChangedCallback = function (name, previous, value) { };
 		try {
 			document.registerElement("vakata-jstree", { prototype: proto });
 		} catch(ignore) { }
 	}
-}(jQuery));
+}($));


### PR DESCRIPTION
Use the local function argument `$` instead to fix the problem.