### PR TITLE
fix data binding issue when creating new instance using $.jstree.create(element, options)

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -110,6 +110,8 @@
 				tmp = tmp.plugin(k, options[k]);
 			}
 		});
+
+		$(el).data('jstree', tmp);
 		tmp.init(el, options);
 		return tmp;
 	};
@@ -231,7 +233,7 @@
 				null;
 			// if there is no instance and no method is being called - create one
 			if(!instance && !is_method && (arg === undefined || $.isPlainObject(arg))) {
-				$(this).data('jstree', new $.jstree.create(this, arg));
+				$.jstree.create(this, arg);
 			}
 			// if there is an instance and no method is called - return the instance
 			if( (instance && !is_method) || arg === true ) {
@@ -308,7 +310,7 @@
 		 *				}
 		 *			]
 		 *		});
-		 *	
+		 *
 		 *	// function
 		 *	$('#tree').jstree({
 		 *		'core' : {

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -111,8 +111,9 @@
 			}
 		});
 
-		$(el).data('jstree', tmp);
 		tmp.init(el, options);
+		$(el).data('jstree', tmp);
+
 		return tmp;
 	};
 	/**


### PR DESCRIPTION
This PR fixes a bug where data was not bound to `jsTree` container element when using `$.jstree.create(element, options)`.

You can reproduce the issue by creating a new instance of `jsTree` as in `$.jstree.create(element, options)` and using drag & drop plugin. A red `X` is always present when dragging a node and you cannot drop it.

The following "if" condition in `$.jstree.reference` method fails because there's no data bound to the container element:
```javascript
if(obj && obj.length && (obj = obj.closest('.jstree')).length && (obj = obj.data('jstree'))) {
    tmp = obj;
}
```

I moved the data binding part from `$.fn.jstree` to `$.jstree.create`. Also, I think that `new` keyword was not necessary in `$(this).data('jstree', new $.jstree.create(this, arg));` because a call to `$.jstree.create()` already returns a new instance if I understand it correctly.

Did some testing and it worked as expected, unless there are some edge cases that I'm not aware of.

Here's the plunker showing the issue: http://plnkr.co/edit/DfezCl?p=preview