### PR TITLE
Use outerHeight to catch border and margin

### DIFF
--- a/src/jstree.dnd.js
+++ b/src/jstree.dnd.js
@@ -171,7 +171,7 @@
 						if(ref && ref.length && ref.parent().is('.jstree-closed, .jstree-open, .jstree-leaf')) {
 							off = ref.offset();
 							rel = data.event.pageY - off.top;
-							h = ref.height();
+							h = ref.outerHeight();
 							if(rel < h / 3) {
 								o = ['b', 'i', 'a'];
 							}


### PR DESCRIPTION
Fixes [#1034](https://github.com/vakata/jstree/issues/1034)