### PR TITLE
Fixed a bug related to yield checked items

### DIFF
--- a/dist/jstree.js
+++ b/dist/jstree.js
@@ -2596,11 +2596,10 @@
 				}
 				else {
 					d
-						.children(".jstree-children").attr("style","display:none !important").end()
+						.children(".jstree-children").attr("style","display:block !important").end()
 						.removeClass("jstree-open").addClass("jstree-closed").attr("aria-expanded", false)
 						.children(".jstree-children").stop(true, true).slideUp(animation, function () {
-							this.style.display = "";
-							//d.children('.jstree-children').remove();
+							d.children(".jstree-children").attr("style","display:none !important");
 							t.trigger("after_close", { "node" : obj });
 						});
 				}

--- a/dist/jstree.js
+++ b/dist/jstree.js
@@ -2596,11 +2596,11 @@
 				}
 				else {
 					d
-						.children(".jstree-children").attr("style","display:block !important").end()
+						.children(".jstree-children").attr("style","display:none !important").end()
 						.removeClass("jstree-open").addClass("jstree-closed").attr("aria-expanded", false)
 						.children(".jstree-children").stop(true, true).slideUp(animation, function () {
 							this.style.display = "";
-							d.children('.jstree-children').remove();
+							//d.children('.jstree-children').remove();
 							t.trigger("after_close", { "node" : obj });
 						});
 				}


### PR DESCRIPTION
Fixed a bug related to yield checked items when node closed.
All functions get_checked() and get_selected() return empty array, when sub-node closed, because ul.jstree-children has been deleted.