### PR TITLE
Check if jstree instance has been destroyed before continuing in onmessage

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1815,6 +1815,9 @@
 						this._data.core.working = true;
 						w = new window.Worker(this._wrk);
 						w.onmessage = $.proxy(function (e) {
+							if (this._wrk === null) { 
+								return; 
+							}
 							rslt.call(this, e.data, true);
 							try { w.terminate(); w = null; } catch(ignore) { }
 							if(this._data.core.worker_queue.length) {


### PR DESCRIPTION
In my application's acceptance tests, I call destroy() on jsTree to cleanup when the test is complete. For tests that are testing other components on the same screen as the tree, these tests end before the tree has finished. So destroy() is called before the worker's onmessage handler is called. This results in test failures with errors "Cannot read property 'find' of null" on this.element.

jsTree should make sure it hasn't already been destroyed before continuing in the onmessage handler.