### PR TITLE
Check if jsTree is destroyed on onmessage and functions that run in timeout

### DIFF
--- a/src/jstree.checkbox.js
+++ b/src/jstree.checkbox.js
@@ -378,7 +378,7 @@
 		 * @plugin checkbox
 		 */
 		this._undetermined = function () {
-            if(null === this._wrk) { return; }
+			if(null === this._wrk) { return; }
 			var i, j, k, l, o = {}, m = this._model.data, t = this.settings.checkbox.tie_selection, s = this._data[ t ? 'core' : 'checkbox' ].selected, p = [], tt = this;
 			for(i = 0, j = s.length; i < j; i++) {
 				if(m[s[i]] && m[s[i]].parents) {

--- a/src/jstree.checkbox.js
+++ b/src/jstree.checkbox.js
@@ -378,6 +378,7 @@
 		 * @plugin checkbox
 		 */
 		this._undetermined = function () {
+            if(null === this._wrk) { return; }
 			var i, j, k, l, o = {}, m = this._model.data, t = this.settings.checkbox.tie_selection, s = this._data[ t ? 'core' : 'checkbox' ].selected, p = [], tt = this;
 			for(i = 0, j = s.length; i < j; i++) {
 				if(m[s[i]] && m[s[i]].parents) {

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -711,7 +711,7 @@
 							}
 							if(!this._data.core.ready) {
 								setTimeout($.proxy(function() {
-                                    if(null === this._wrk) { return; }
+									if(null === this._wrk) { return; }
 									if(!this.get_container_ul().find('.jstree-loading').length) {
 										this._data.core.ready = true;
 										if(this._data.core.selected.length) {
@@ -1816,7 +1816,7 @@
 						this._data.core.working = true;
 						w = new window.Worker(this._wrk);
 						w.onmessage = $.proxy(function (e) {
-                            if(null === this._wrk) { return; }
+							if(null === this._wrk) { return; }
 							rslt.call(this, e.data, true);
 							try { w.terminate(); w = null; } catch(ignore) { }
 							if(this._data.core.worker_queue.length) {

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -711,6 +711,7 @@
 							}
 							if(!this._data.core.ready) {
 								setTimeout($.proxy(function() {
+                                    if(null === this._wrk) { return; }
 									if(!this.get_container_ul().find('.jstree-loading').length) {
 										this._data.core.ready = true;
 										if(this._data.core.selected.length) {
@@ -1815,6 +1816,7 @@
 						this._data.core.working = true;
 						w = new window.Worker(this._wrk);
 						w.onmessage = $.proxy(function (e) {
+                            if(null === this._wrk) { return; }
 							rslt.call(this, e.data, true);
 							try { w.terminate(); w = null; } catch(ignore) { }
 							if(this._data.core.worker_queue.length) {


### PR DESCRIPTION
In my application's acceptance tests, I call destroy() on jsTree to cleanup when the test is complete. For tests that are testing other components on the same screen as the tree, these tests end before the tree has finished. So destroy() is called before the worker's onmessage handler is called. This results in test failures with errors "Cannot read property 'find' of null" on this.element.

jsTree should make sure it hasn't already been destroyed before continuing in the onmessage handler and functions that run in a timeout.