### PR TITLE
Update jstree.checkbox.js to allow checkbox/selection separation

### DIFF
--- a/src/jstree.checkbox.js
+++ b/src/jstree.checkbox.js
@@ -67,7 +67,13 @@
 		 * @name $.jstree.defaults.checkbox.tie_selection
 		 * @plugin checkbox
 		 */
-		tie_selection		: true
+		tie_selection		: true,
+		/**
+		 * This setting controls if clicking on a node checks it. Defaults to `true`, only set to `false` if you know exactly what you are doing. If set to false, tie_selection will also be set to false.
+		 * @name $.jstree.defaults.checkbox.check_by_selection
+		 * @plugin checkbox
+		 */
+		check_by_selection	: true
 	};
 	$.jstree.plugins.checkbox = function (options, parent) {
 		this.bind = function () {
@@ -76,6 +82,9 @@
 			this._data.checkbox.selected = [];
 			if(this.settings.checkbox.three_state) {
 				this.settings.checkbox.cascade = 'up+down+undetermined';
+			}
+			if(!this.settings.checkbox.check_by_selection) {
+				this.settings.checkbox.tie_selection = false;
 			}
 			this.element
 				.on("init.jstree", $.proxy(function () {
@@ -509,13 +518,16 @@
 			if(this.is_disabled(obj)) {
 				return false;
 			}
-			if(this.is_checked(obj)) {
-				this.uncheck_node(obj, e);
+			
+			if(this.settings.checkbox.check_by_selection || $(e.target).hasClass("jstree-checkbox")) {
+				if(this.is_checked(obj)) {
+					this.uncheck_node(obj, e);
+				}
+				else {
+					this.check_node(obj, e);
+				}
 			}
-			else {
-				this.check_node(obj, e);
-			}
-			this.trigger('activate_node', { 'node' : this.get_node(obj) });
+			this.trigger('activate_node', { 'node' : this.get_node(obj), 'event' : e });
 		};
 
 		/**


### PR DESCRIPTION
It is not always desirable to check a checkbox associated with a node when the node is simply clicked upon. In my case, I wish to use this particular event to show additional details about a node. I have therefore added a check_by_selection option which defaults to true. This is used to determine what triggers a node to be checked/unchecked. If it is set to true, clicking anywhere on the node will toggle it. If set to false, only clicking on the checkbox will trigger this.