### PR TITLE
Added a return statement to the search plugin, so that the search fun…

### DIFF
--- a/src/jstree.search.js
+++ b/src/jstree.search.js
@@ -236,6 +236,7 @@
 			 * @plugin search
 			 */
 			this.trigger('search', { nodes : this._data.search.dom, str : str, res : this._data.search.res, show_only_matches : show_only_matches });
+			return this._data.search.res;
 		};
 		/**
 		 * used to clear the last search (removes classes and shows all nodes if filtering is on)


### PR DESCRIPTION
…ction also returns the found items.

I did this because even if you set 'show_only_matches' to true, a search with no matches will in fact show the whole tree. Which is a behavior that seems counter-intuitive, since results with matches will reduce the tree to show only those matches when the  'show_only_matches' flag is set.
Not knowing if this behavior was intentional, I simply added the return statement so that one can check if the search result array length is 0, and then take whatever actions one seems fit. In my case, it would be to hide the tree.