### PR TITLE
search plugin: performance increase at  _search_open (open found nodes)

### DIFF
--- a/src/jstree.search.js
+++ b/src/jstree.search.js
@@ -260,17 +260,30 @@
 		 * @plugin search
 		 */
 		this._search_open = function (d) {
-			var t = this;
-			$.each(d.concat([]), function (i, v) {
-				if(v === $.jstree.root) { return true; }
-				try { v = $('#' + v.replace($.jstree.idregex,'\\$&'), t.element); } catch(ignore) { }
-				if(v && v.length) {
-					if(t.is_closed(v)) {
-						t._data.search.opn.push(v[0].id);
-						t.open_node(v, function () { t._search_open(d); }, 0);
-					}
-				}
-			});
+		    var t = this;
+
+		    var potentialNewWork;
+		    do {
+		        potentialNewWork = false;
+		        for (var i = 0; i < d.length;) {
+		            var v = d[i];
+		            if (v !== $.jstree.root) {
+		                try { v = $('#' + v.replace($.jstree.idregex, '\\$&'), t.element); } catch (ignore) { }
+
+		                if (v && v.length) {
+		                    if (t.is_closed(v)) {
+		                        t._data.search.opn.push(v[0].id);
+		                        t.open_node(v, null, 0);
+		                        potentialNewWork = true;
+
+		                        d.splice(i, 1);
+		                        continue;
+		                    }
+		                }
+		            }
+		            i++;
+		        }
+		    } while (potentialNewWork);
 		};
 
 		this.redraw_node = function(obj, deep, callback, force_render) {


### PR DESCRIPTION
As already known there is a performance issue, when a lot of nodes are found within a search.
Or more precise when these nodes are expanded.

This patch provides two improvements.
First, it transforms the recursive algorithm to an iterative one.
Secondly, the runtime complexity is reduced from [d^2] to [d x log d]. (Where d are nodes that are closed and should be opened.)

Note: litte behaviour change: The given array d is modified (cleared) in the course of the algorithm.
=> Array copy is required, if d should be preserved.

(very short) Evaluation:
Where d.length = 112:
In Chrome (Version 44.0.2403.155 m) we've noticed an increase from 45072ms to 777ms (execution time of _search_open).
Sadly, thats not enough for IE. Especially because we've to support it. :(