### PR TITLE
Adjust when the type of data is string

### DIFF
--- a/dist/jstree.js
+++ b/dist/jstree.js
@@ -1490,6 +1490,11 @@
 					data = JSON.parse(data);
 				}
 			}
+			
+			if(typeof data === "string") {
+				data = JSON.parse(data);
+			}
+			
 			if(!$.isArray(data)) { data = [data]; }
 			var w = null,
 				args = {


### PR DESCRIPTION
Testing via Ajax and the type of data returned need "convert" using JSON.parse method.