### PR TITLE
Adding additional options to the types plugin

### DIFF
--- a/src/jstree.types.js
+++ b/src/jstree.types.js
@@ -81,6 +81,29 @@
 							if(m[dpc[i]].icon === true && t[c].icon !== undefined) {
 								m[dpc[i]].icon = t[c].icon;
 							}
+							
+							if(t[c].template !== undefined) {
+								m[dpc[i]].text = t[c].template;
+
+								if(m[dpc[i]].original.template_data) {
+									var workingText = m[dpc[i]].text;
+									$.each(m[dpc[i]].original.template_data, function(key, value) {
+										var regExp = new RegExp("\{\{"+key+"}}", "g");
+										workingText = workingText.replace(regExp, value);
+									});
+									m[dpc[i]].text = workingText;
+								}
+							}
+
+							if(t[c].a_attr !== undefined) {
+								if(m[dpc[i]].a_attr) {
+									$.each(t[c].a_attr, function(key, value) {
+										m[dpc[i]].a_attr[key] = value;
+									});
+								} else {
+									m[dpc[i]].a_attr = t[c].a_attr;
+								}
+							}
 						}
 						m[$.jstree.root].type = $.jstree.root;
 					}, this));


### PR DESCRIPTION
Add the ability to provide a template for the text of the node and also default attributes for the a_attr property.  The idea here is to provide a way of keeping HTML related to a node in javascript as opposed to providing it in the JSON.  Building out HTML on the server isn't necessarily ideal.  Let me know if there's another approach or if I missed something.

Below is an example.

$("#container").jstree({
        'plugins': ["wholerow", "types"],
        'types': {
            'organization': {
                'template': '{{orgId}} <span class="progress progress-jstree"><span class="progress-bar progress-bar-success" style="width: {{success_width}}%">{{success_width}}% ({{success_total}})</span><span class="progress-bar progress-bar-warning" style="width: {{warning_width}}%">{{warning_width}}% ({{warning_total}})</span><span class="progress-bar progress-bar-danger" style="width: {{danger_width}}%">{{danger_width}}% ({{danger_total}})</span></span> <span class="custom-org-total">Total:</span> {{item_total}}',
                'a_attr': {"style": "width: 99%; display: inline-flex; flex-direction: row;"}
            },
            'text_with_total': {
                'template': '{{text}} <span class="custom-badge">{{total}}</span>'
            }
        },
        'core': {
            'data': [{
                "type": "organization",
                "template_data": {
                    orgId: 'A',
                    'success_width': 50,
                    'success_total': 100,
                    'warning_width': 30,
                    'warning_total': 60,
                    'danger_width': 20,
                    'danger_total': 40,
                    'item_total': 200
                },
                "children": [{
                    "type": "organization",
                    "template_data": {
                        orgId: 'B',
                        'success_width': 80,
                        'success_total': 80,
                        'warning_width': 0,
                        'warning_total': 0,
                        'danger_width': 20,
                        'danger_total': 20,
                        'item_total': 100
                    },
                    "children": [{
                        "text": "Summary",
                        "children": [{
                            "text": "D",
                            "children": [{
                                type: "text_with_total",
                                template_data: {
                                    text: 'A',
                                    total: 3
                                }
                            }
                            ]
                        },
                        ]
                    }]
                }]
            }]
        }
    });