### PR TITLE
Node Customize Plugin

### DIFF
--- a/src/jstree-node-customize.js
+++ b/src/jstree-node-customize.js
@@ -1,0 +1,53 @@
+/**
+ * ### Node Customize plugin
+ *
+ * Allows to customize nodes when they are drawn.
+ */
+/*globals jQuery, define, exports, require */
+(function (factory) {
+	"use strict";
+	if (typeof define === 'function' && define.amd) {
+		define('jstree.node_customize', ['jquery','jstree'], factory);
+	}
+	else if(typeof exports === 'object') {
+		factory(require('jquery'), require('jstree'));
+	}
+	else {
+		factory(jQuery, jQuery.jstree);
+	}
+}(function ($, jstree, undefined) {
+	"use strict";
+
+	if($.jstree.plugins.node_customize) { return; }
+
+	/**
+	 * the settings object.
+	 * key is the attribute name to select the customizer function from map.
+	 * switch is a key => function(el, node) map.
+	 * default: function(el, node) will be called if the type could not be mapped
+	 * @name $.jstree.defaults.node_customize
+	 * @plugin node_customize
+	 */
+	$.jstree.defaults.node_customize = {
+		"key": "type",
+		"switch": {},
+		"default": null
+	};
+
+	$.jstree.plugins.node_customize = function (options, parent) {
+		this.redraw_node = function (obj, deep, callback, force_draw) {
+			var node_id = obj;
+			var el = parent.redraw_node.apply(this, arguments);
+			if (el) {
+				var node = this._model.data[node_id];
+				var cfg = this.settings.node_customize;
+				var key = cfg.key;
+				var type =  (node && node.original && node.original[key]);
+				var customizer = (type && cfg.map[type]) || cfg.default;
+				if(customizer)
+					customizer(el, node);
+			}
+			return el;
+		};
+	}
+}));

--- a/src/jstree-node-customize.js
+++ b/src/jstree-node-customize.js
@@ -22,7 +22,7 @@
 
 	/**
 	 * the settings object.
-	 * key is the attribute name to select the customizer function from map.
+	 * key is the attribute name to select the customizer function from switch.
 	 * switch is a key => function(el, node) map.
 	 * default: function(el, node) will be called if the type could not be mapped
 	 * @name $.jstree.defaults.node_customize
@@ -43,7 +43,7 @@
 				var cfg = this.settings.node_customize;
 				var key = cfg.key;
 				var type =  (node && node.original && node.original[key]);
-				var customizer = (type && cfg.map[type]) || cfg.default;
+				var customizer = (type && cfg.switch[type]) || cfg.default;
 				if(customizer)
 					customizer(el, node);
 			}


### PR DESCRIPTION
I've been looking for some way to change the node when its being drawn.
I found #1068, but the approach is very specific and the options are not all usable as advertised.
So I've tried to take a generic approach to create a very simple plugin.
The configuration is quite simple:

```javascript
"node_customize": {
    "key": "type", // default is "type", so only change if you want to use something else
    "switch": {
        "type1": function (el, node) {
            el.title = 'hello';
        },
        "type2": function (el, node) {
            el.title = 'world';
        }
    },
    "default": function (el, node) {
        el.title = 'foo bar';
    }
}
```

This looks at a node configuration and if it has a property "type" (configurable as seen above), it will try to find a matching function in the map "switch". If no type was specified, or no entry was found in switch, default gets called.

It can be used to set title attribute, add custom buttons, etc.