### PR TITLE
suggest instead of requiring robloach/component-installer in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,10 @@
 		}
 	],
 	"require": {
-		"robloach/component-installer": "*",
 		"components/jquery": ">=1.9.1"
+	},
+	"suggest": {
+		"robloach/component-installer": "Allows installation of Components via Composer"
 	},
 	"extra": {
 		"component": {


### PR DESCRIPTION
component-installer might not fit to all workflows and it is not really required to use jstree in a project