### PR TITLE
fix: guard against unnecessary events fired

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3370,7 +3370,7 @@
 						this.set_state(state, callback);
 						return false;
 					}
-					if(state.core.selected) {
+					if(state.core.selected && state.core.selected.length) {
 						_this = this;
 						this.deselect_all();
 						$.each(state.core.selected, function (i, v) {


### PR DESCRIPTION
When doing a ```.jstree('refresh')```, it will call ```set_state``` https://github.com/vakata/jstree/blob/master/src/jstree.js#L3416 and due to the fact that ```state.core.selected``` is an empty array and not undefined, it will fired ```deselect_all``` event unnecessarily.

this is to fix that by additional conditions to prevent that.