### PR TITLE
Use minified jquery in browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
         "themes/**/*.min.css"
       ]
     }
-  ]
+  ],
+  "browser": {
+    "jquery" : "jquery/dist/jquery.min.js"
+  }
 }


### PR DESCRIPTION
This makes jstree use jquery.min.js instead of jquery.js when using browserify to include jstree as a dependency, i.e. using

```javascript
require('jquery');
```

in the code.