### PR TITLE
Allow item to be copied into itself

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3856,7 +3856,7 @@
 			var tmp = chk.match(/^move_node|copy_node|create_node$/i) ? par : obj,
 				chc = this.settings.core.check_callback;
 			if(chk === "move_node" || chk === "copy_node") {
-				if((!more || !more.is_multi) && (obj.id === par.id || (chk === "move_node" && $.inArray(obj.id, par.children) === pos) || $.inArray(par.id, obj.children_d) !== -1)) {
+				if((!more || !more.is_multi) && ((obj.id === par.id && chk !== "copy_node") || (chk === "move_node" && $.inArray(obj.id, par.children) === pos) || $.inArray(par.id, obj.children_d) !== -1)) {
 					this._data.core.last_error = { 'error' : 'check', 'plugin' : 'core', 'id' : 'core_01', 'reason' : 'Moving parent inside child', 'data' : JSON.stringify({ 'chk' : chk, 'pos' : pos, 'obj' : obj && obj.id ? obj.id : false, 'par' : par && par.id ? par.id : false }) };
 					return false;
 				}


### PR DESCRIPTION
It is currently not possible to copy an element and paste it into itself. Neither through the context menu nor programmatically. This is the correct behaviour for cut & paste yet should be allowed for copy and paste.

Let's assume we have one tree element and we want to copy it. copyFromId would be 1 and copyToId 1 as well. The check makes it impossible to pass due to the matching condition. We need to check there additionally for the type "copy_node" as it should fail using "move_node".

In my code example:

```
jstree('copy', copyFromId);
jstree('paste', copyToId, 'last');
```

This would return the error "Moving parent inside child".

