### PR TITLE
More options in get_json method

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3602,6 +3602,8 @@
 		 * @name get_json([obj, options])
 		 * @param  {mixed} obj
 		 * @param  {Object} options
+		 * @param  {Boolean} options.no_li_attr do not include li_attr information
+		 * @param  {Boolean} options.no_a_attr do not include a_attr information
 		 * @param  {Boolean} options.no_state do not return state information
 		 * @param  {Boolean} options.no_id do not return ID
 		 * @param  {Boolean} options.no_children do not include children
@@ -3611,54 +3613,72 @@
 		 */
 		get_json : function (obj, options, flat) {
 			obj = this.get_node(obj || $.jstree.root);
-			if(!obj) { return false; }
-			if(options && options.flat && !flat) { flat = []; }
-			var tmp = {
-				'id' : obj.id,
-				'text' : obj.text,
-				'icon' : this.get_icon(obj),
-				'li_attr' : $.extend(true, {}, obj.li_attr),
-				'a_attr' : $.extend(true, {}, obj.a_attr),
-				'state' : {},
-				'data' : options && options.no_data ? false : $.extend(true, {}, obj.data)
-				//( this.get_node(obj, true).length ? this.get_node(obj, true).data() : obj.data ),
-			}, i, j;
-			if(options && options.flat) {
-				tmp.parent = obj.parent;
-			}
-			else {
-				tmp.children = [];
-			}
-			if(!options || !options.no_state) {
-				for(i in obj.state) {
-					if(obj.state.hasOwnProperty(i)) {
-						tmp.state[i] = obj.state[i];
-					}
-				}
-			}
-			if(options && options.no_id) {
-				delete tmp.id;
-				if(tmp.li_attr && tmp.li_attr.id) {
-					delete tmp.li_attr.id;
-				}
-				if(tmp.a_attr && tmp.a_attr.id) {
-					delete tmp.a_attr.id;
-				}
-			}
-			if(options && options.flat && obj.id !== $.jstree.root) {
-				flat.push(tmp);
-			}
-			if(!options || !options.no_children) {
-				for(i = 0, j = obj.children.length; i < j; i++) {
-					if(options && options.flat) {
-						this.get_json(obj.children[i], options, flat);
-					}
-					else {
-						tmp.children.push(this.get_json(obj.children[i], options));
-					}
-				}
-			}
-			return options && options.flat ? flat : (obj.id === $.jstree.root ? tmp.children : tmp);
+            if (!obj) {
+                return false; }
+            if (options && options.flat && !flat) { flat = []; }
+            var tmp = {
+                    'id': obj.id,
+                    'text': obj.text,
+                    'icon': 'fileIcon',
+                    'li_attr': '',
+                    'a_attr': '',
+                    'state': {},
+                    'data': ''
+                    //( this.get_node(obj, true).length ? this.get_node(obj, true).data() : obj.data ),
+                },
+                i, j;
+            if (options && options.no_data) {
+                delete tmp.data;
+            } else {
+                tmp.data = $.extend(true, {}, obj.data);
+            }
+            if (options && options.no_li_attr) {
+                delete tmp.li_attr;
+            } else {
+                tmp.li_attr = $.extend(true, {}, obj.li_attr);
+            }
+            if (options && options.no_a_attr) {
+                delete tmp.a_attr;
+            } else {
+                tmp.a_attr = $.extend(true, {}, obj.a_attr);
+            }
+            if (options && options.flat) {
+                tmp.parent = obj.parent;
+            } else {
+                tmp.children = [];
+            }
+            if (!options || !options.no_state) {
+                for (i in obj.state) {
+                    if (obj.state.hasOwnProperty(i)) {
+                        tmp.state[i] = obj.state[i];
+                    }
+                }
+            } else
+                delete tmp.state;
+            if (options && options.no_id) {
+                delete tmp.id;
+                if (tmp.li_attr && tmp.li_attr.id) {
+                    delete tmp.li_attr.id;
+                }
+                if (tmp.a_attr && tmp.a_attr.id) {
+                    delete tmp.a_attr.id;
+                }
+            }
+            if (options && options.flat && obj.id !== $.jstree.root) {
+                flat.push(tmp);
+            }
+            if (!options || !options.no_children) {
+                if (obj.children.length < 1 && (obj.id != $.jstree.root))
+                    delete tmp.children;
+                for (i = 0, j = obj.children.length; i < j; i++) {
+                    if (options && options.flat) {
+                        this.get_own_json(obj.children[i], options, flat);
+                    } else {
+                        tmp.children.push(this.get_own_json(obj.children[i], options));
+                    }
+                }
+            }
+            return options && options.flat ? flat : (obj.id === $.jstree.root ? tmp.children : tmp);
 		},
 		/**
 		 * create a new node (do not confuse with load_node)


### PR DESCRIPTION
Hi there,

Currently in jstree's `get_json` method to get JSON representation of a node/whole tree , we pass two argument **obj** and **options**. 

In options object previously we can only pass `no_state`,`no_id`,`no_children`,`no_data` and `flat` , through this pull request and my changes you can also pass `no_li_attr` and `no_a_attr` this gives us more fine grain control over `get_json` method and now client has full control over what he/she wants to be returned through `get_json` method.

Please tell me if any other information is required for this pull request or changes to be merged.
This is my first pull request on any project on github so please let me know your suggestion and all.

Thanks & Regards,
Tarun Garg