### PR TITLE
Fix error on hiding context menu for a column

### DIFF
--- a/src/jstree.contextmenu.js
+++ b/src/jstree.contextmenu.js
@@ -234,7 +234,7 @@
 			*/
 			$(document).on("context_hide.vakata.jstree", $.proxy(function (e, data) {
 				this._data.contextmenu.visible = false;
-				data.reference.removeClass('jstree-context');
+				$(data.reference).removeClass('jstree-context');
 			}, this));
 		};
 		this.teardown = function () {


### PR DESCRIPTION
This fix prevents the "data.reference.removeClass" error to happen by wrapping the reference object with jquery when the "context_hide.vakata.jstree" event is raised.

This is happening to me by opening the context menu on a cell using the jstree-grid plugin.

This happens because the data.reference is a pure DOM object.

Wrapping this object with jquery makes possible to call the removeClass method.

Thanks for this great plugin!! it is amazing!.