### PR TITLE
fix for being able to execute context_menu action by keyboard

### DIFF
--- a/src/jstree.contextmenu.js
+++ b/src/jstree.contextmenu.js
@@ -580,7 +580,7 @@
 						switch(e.which) {
 							case 13:
 							case 32:
-								e.type = "mouseup";
+								e.type = "click";
 								e.preventDefault();
 								$(e.currentTarget).trigger(e);
 								break;


### PR DESCRIPTION
keys space and enter was generating mouseup but there is no handler for the event.

I think it is broken while fixing issue #706.