### PR TITLE
documentation: fix hide_node redraw arg

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2880,7 +2880,7 @@
 		 * hides a node - it is still in the structure but will not be visible
 		 * @name hide_node(obj)
 		 * @param {mixed} obj the node to hide
-		 * @param {Boolean} redraw internal parameter controlling if redraw is called
+		 * @param {Boolean} skip_redraw internal parameter controlling if redraw is called
 		 * @trigger hide_node.jstree
 		 */
 		hide_node : function (obj, skip_redraw) {


### PR DESCRIPTION
documentation did not reflect redraw arg causing
redraws when not intended.
