### PR TITLE
Documentation: Change 'Getting Started' section to reference latest stable JQuery & JSTree Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ To get started you need 3 things in your page:
  3. The jstree source file
 
 ```html
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jstree/3.0.9/themes/default/style.min.css" />
-<script src="//cdnjs.cloudflare.com/ajax/libs/jstree/3.0.9/jstree.min.js"></script>
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/themes/default/style.min.css" />
+<script src="//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 ```
 
 _If you decide to host jstree yourself - the files are located in the `dist` folder. You can safely ignore the `dist/libs` folder._


### PR DESCRIPTION
Simple docs update to update the CDNJS links in 'Getting Started' section.
