### PR TITLE
"checkbox" and "lazyload" jstree will have a endless loop when checknode

### DIFF
--- a/dist/jstree.js
+++ b/dist/jstree.js
@@ -1662,7 +1662,12 @@
 									tmp.state[i] = df[i];
 								}
 							}
-							if(d && d.id) { tmp.id = d.id.toString(); }
+							if(d && d.id) { 
+								tmp.id = d.id.toString(); 
+								if(d.id == p && ps.length > 1){
+									d.id = ps[1];
+								}
+							}
 							if(d && d.text) { tmp.text = d.text; }
 							if(d && d.data && d.data.jstree && d.data.jstree.icon) {
 								tmp.icon = d.data.jstree.icon;


### PR DESCRIPTION
a "checkbox" and "lazyload" jstree will have a endless loop，

because when trigger a "check_node" or "select_node" event (line 5027) , especially in the "apply up" part(line 5052),there is a error that par.id == par.parent,

the error caused when _append_json_data(line 1513),if open a node A,jstree will parse_nest(line 1637) node A and A's children,when parse node A ,the param "p" == A.id, so A.parent will be changed to be a wrong value.

SOLUTION: get the right parent from ps(line 1637)