### PR TITLE
Preserve array data

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3640,7 +3640,7 @@
 				'li_attr' : $.extend(true, {}, obj.li_attr),
 				'a_attr' : $.extend(true, {}, obj.a_attr),
 				'state' : {},
-				'data' : options && options.no_data ? false : (Array.isArray(obj.data) ? obj.data.slice() : $.extend(true, {}, obj.data))
+				'data' : options && options.no_data ? false : ($.isArray(obj.data) ? obj.data.slice() : $.extend(true, {}, obj.data))
 				//( this.get_node(obj, true).length ? this.get_node(obj, true).data() : obj.data ),
 			}, i, j;
 			if(options && options.flat) {

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3640,7 +3640,7 @@
 				'li_attr' : $.extend(true, {}, obj.li_attr),
 				'a_attr' : $.extend(true, {}, obj.a_attr),
 				'state' : {},
-				'data' : options && options.no_data ? false : $.extend(true, {}, obj.data)
+				'data' : options && options.no_data ? false : (Array.isArray(obj.data) ? obj.data.slice() : $.extend(true, {}, obj.data))
 				//( this.get_node(obj, true).length ? this.get_node(obj, true).data() : obj.data ),
 			}, i, j;
 			if(options && options.flat) {


### PR DESCRIPTION
When calling "get_node", data is returned as-is (as expected), but when doing "get_json", just to parse all the data arrays, you notice that they are converted to an object (not expected).

Right now I have to reconvert those objects to arrays, and that's not optimal.