### PR TITLE
Add parentsall and parentmaster in get_json

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3673,6 +3673,12 @@
 					delete tmp.a_attr.id;
 				}
 			}
+			if(options && options.parentsall) {
+                               tmp.parentsall = obj.parents;
+			}      
+			if(options && options.parentmaster) {
+                               tmp.parentmaster = obj.parents[(obj.parents.length)-2] ? obj.parents[(obj.parents.length)-2] : $.jstree.root;                         
+			}  			
 			if(options && options.flat && obj.id !== $.jstree.root) {
 				flat.push(tmp);
 			}


### PR DESCRIPTION
Very useful in php applications

options.parentsall return  obj.parents;
options.parentmaster return first parent related to each children's tree 

Sorry for bad English.
I'm using google translator