### PR TITLE
Keep object instances inside data

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1405,7 +1405,13 @@
 								this.settings.core.error.call(this, this._data.core.last_error);
 							}, this));
 				}
-				t = ($.isArray(s) || $.isPlainObject(s)) ? JSON.parse(JSON.stringify(s)) : s;
+				if ($.isArray(s)) {
+					t = $.extend(true, [], s);
+				} else if ($.isPlainObject(s)) {
+					t = $.extend(true, {}, s);
+				} else {
+					t = s;
+				}
 				if(obj.id === $.jstree.root) {
 					return this._append_json_data(obj, t, function (status) {
 						callback.call(this, status);


### PR DESCRIPTION
If I add an instance of an object to the `data` property, it will not work because of `JSON.parse`. Adding deep jQuery extend method checks for those instances, creating a deep copy of the objects or arrays but keeping the object instances untouched.

``` js
var cobj = {
    copyme: true,
    deepcopyme: {
         copyme: true
    }
};
var obj = $.extend(true, {}, cobj);
// obj == cobj returns false
// obj.deepcopyme == cobj.deepcopyme returns false

function instanceme() {
}
var instance = new instanceme();
var cobj = {
    copyme: instance
};
var obj = $.extend(true, {}, cobj);
// obj == cobj returns false
// obj.copyme == instance returns true, as expected
```

Using `JSON.parse` and `JSON.stringify` not only breaks the instance, but throws an error if the instance has a cyclic reference.