### PR TITLE
Avoid destructive `create_node`

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3708,7 +3708,11 @@
 				return this.load_node(par, function () { this.create_node(par, node, pos, callback, true); });
 			}
 			if(!node) { node = { "text" : this.get_string('New node') }; }
-			if(typeof node === "string") { node = { "text" : node }; }
+			if(typeof node === "string") {
+				node = { "text" : node };
+			} else {
+				node = $.extend(true, {}, node);
+			}
 			if(node.text === undefined) { node.text = this.get_string('New node'); }
 			var tmp, dpc, i, j;
 


### PR DESCRIPTION
Maybe the object passed is used for more things after creating the node.

If I pass an object with `data` and `children` to `create_node` and later want to read the same object, `data` and `children` will be deleted.

I can fix it by doing a jQuery `extend` to the object before passing it to `create_node` inside my code, but as an object being modified when passing it to a method is not an expected behavior, I added it inside `create_node`, so others don't have the same problem as me.