### PR TITLE
Added 'edit' check_callback

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -338,7 +338,7 @@
 		 *	$('#tree').jstree({
 		 *		'core' : {
 		 *			'check_callback' : function (operation, node, node_parent, node_position, more) {
-		 *				// operation can be 'create_node', 'rename_node', 'delete_node', 'move_node' or 'copy_node'
+		 *				// operation can be 'create_node', 'rename_node', 'delete_node', 'move_node', 'copy_node' or 'edit'
 		 *				// in case of 'rename_node' node_position is filled with the new node name
 		 *				return operation === 'rename_node' ? true : false;
 		 *			}
@@ -4369,8 +4369,7 @@
 			var rtl, w, a, s, t, h1, h2, fn, tmp, cancel = false;
 			obj = this.get_node(obj);
 			if(!obj) { return false; }
-			if(this.settings.core.check_callback === false) {
-				this._data.core.last_error = { 'error' : 'check', 'plugin' : 'core', 'id' : 'core_07', 'reason' : 'Could not edit node because of check_callback' };
+			if(!this.check("edit", obj, this.get_parent(obj))) {
 				this.settings.core.error.call(this, this._data.core.last_error);
 				return false;
 			}


### PR DESCRIPTION
Because `edit` and `rename_node` differs in use, I added another `check_callback` option where `edit` can be cancelled.

Right now to cancel the `edit` command we have to block completely the `check_callback` method, but I want to keep some `check_callback` options enabled and also disable the `edit` option in some special nodes (but not renaming programmatically).

I've done this because I don't want users to edit non-editable nodes with `F2` but I want to rename them programmatically at some point, so I had to difference between both events.

Also, it will be less confusing as blocking the `rename` event but not the `edit` event (like now is done) will let the user open the edit box and input something, although the node name is not changed.