### PR TITLE
Serialization array deep extend fix

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3646,7 +3646,7 @@
 				'li_attr' : $.extend(true, {}, obj.li_attr),
 				'a_attr' : $.extend(true, {}, obj.a_attr),
 				'state' : {},
-				'data' : options && options.no_data ? false : ($.isArray(obj.data) ? obj.data.slice() : $.extend(true, {}, obj.data))
+				'data' : options && options.no_data ? false : $.extend(true, $.isArray(obj.data)?[]:{}, obj.data)
 				//( this.get_node(obj, true).length ? this.get_node(obj, true).data() : obj.data ),
 			}, i, j;
 			if(options && options.flat) {


### PR DESCRIPTION
The old one used `slice()`, which only makes a copy of the main array but not the objects inside the array, returning real references to the objects. Not expected behaviour.

This patch uses jQuery deep `extend()` for both objects and arrays.