### PR TITLE
Add ability to use own ajax transport

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -64,7 +64,12 @@
 			 * configure which plugins will be active on an instance. Should be an array of strings, where each element is a plugin name. The default is `[]`
 			 * @name $.jstree.defaults.plugins
 			 */
-			plugins : []
+			plugins : [],
+		        transport: function(params, success, error) {
+			  return $.ajax(params)
+			    .then(success)
+			    .catch(error);
+		        }
 		},
 		/**
 		 * stores all loaded jstree plugins (used internally)
@@ -1384,8 +1389,8 @@
 					if($.isFunction(s.data)) {
 						s.data = s.data.call(this, obj);
 					}
-					return $.ajax(s)
-						.done($.proxy(function (d,t,x) {
+					return this.settings.transport(s,
+						$.proxy(function (d,t,x) {
 								var type = x.getResponseHeader('Content-Type');
 								if((type && type.indexOf('json') !== -1) || typeof d === "object") {
 									return this._append_json_data(obj, d, function (status) { callback.call(this, status); });
@@ -1398,8 +1403,8 @@
 								this._data.core.last_error = { 'error' : 'ajax', 'plugin' : 'core', 'id' : 'core_04', 'reason' : 'Could not load node', 'data' : JSON.stringify({ 'id' : obj.id, 'xhr' : x }) };
 								this.settings.core.error.call(this, this._data.core.last_error);
 								return callback.call(this, false);
-							}, this))
-						.fail($.proxy(function (f) {
+							}, this),
+						$.proxy(function (f) {
 								callback.call(this, false);
 								this._data.core.last_error = { 'error' : 'ajax', 'plugin' : 'core', 'id' : 'core_04', 'reason' : 'Could not load node', 'data' : JSON.stringify({ 'id' : obj.id, 'xhr' : f }) };
 								this.settings.core.error.call(this, this._data.core.last_error);

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -65,6 +65,14 @@
 			 * @name $.jstree.defaults.plugins
 			 */
 			plugins : [],
+			/**
+			 * configure a transport for ajax call. You can use own ajax service (eg. fetch). Default $.ajax
+			 * Success function must have 3 arguments:
+			 * 	* data - the data returned
+			 *	* statusText
+			 *	* raw - the raw response. This object must provide getResponseHeader method who return a headers of response by key (see jquery implementation http://api.jquery.com/jQuery.ajax/#jqXHR)
+			 * @name $.jstree.defaults.transport
+			 */
 		        transport: function(params, success, error) {
 			  return $.ajax(params)
 			    .then(success)

--- a/src/jstree.massload.js
+++ b/src/jstree.massload.js
@@ -89,8 +89,8 @@
 						if($.isFunction(s.data)) {
 							s.data = s.data.call(this, toLoad);
 						}
-						return $.ajax(s)
-							.done($.proxy(function (data,t,x) {
+						return this.settings.transport(s,
+							$.proxy(function (data,t,x) {
 									var i, j;
 									if(data) {
 										for(i in data) {
@@ -106,8 +106,8 @@
 										}
 									}
 									parent._load_nodes.call(this, nodes, callback, is_callback, force_reload);
-								}, this))
-							.fail($.proxy(function (f) {
+								}, this),
+							$.proxy(function (f) {
 									parent._load_nodes.call(this, nodes, callback, is_callback, force_reload);
 								}, this));
 					}

--- a/src/jstree.search.js
+++ b/src/jstree.search.js
@@ -176,16 +176,16 @@
 					if (this._data.search.lastRequest) {
 						this._data.search.lastRequest.abort();
 					}
-					this._data.search.lastRequest = $.ajax(a)
-						.fail($.proxy(function () {
-							this._data.core.last_error = { 'error' : 'ajax', 'plugin' : 'search', 'id' : 'search_01', 'reason' : 'Could not load search parents', 'data' : JSON.stringify(a) };
-							this.settings.core.error.call(this, this._data.core.last_error);
-						}, this))
-						.done($.proxy(function (d) {
+					this._data.search.lastRequest = this.settings.transport(a,
+						$.proxy(function (d) {
 							if(d && d.d) { d = d.d; }
 							this._load_nodes(!$.isArray(d) ? [] : $.vakata.array_unique(d), function () {
 								this.search(str, true, show_only_matches, inside, append, show_only_matches_children);
 							});
+						}, this),
+						$.proxy(function () {
+							this._data.core.last_error = { 'error' : 'ajax', 'plugin' : 'search', 'id' : 'search_01', 'reason' : 'Could not load search parents', 'data' : JSON.stringify(a) };
+							this.settings.core.error.call(this, this._data.core.last_error);
 						}, this));
 					return this._data.search.lastRequest;
 				}


### PR DESCRIPTION
With this pull request you can use your own transport ajax.
From jQuery 3 you can customize the dependencies of jQuery, for example by removing the ajax module.
Also with the new `fetch` standard you can leverage api already in the browser.