### PR TITLE
check if get_node() return a `false`

### DIFF
--- a/src/jstree.checkbox.js
+++ b/src/jstree.checkbox.js
@@ -414,6 +414,9 @@
 			this.element.find('.jstree-closed').not(':has(.jstree-children)')
 				.each(function () {
 					var tmp = tt.get_node(this), tmp2;
+					
+					if( !tmp ) return;	//get_node() simetimes return a `false`
+					
 					if(!tmp.state.loaded) {
 						if(tmp.original && tmp.original.state && tmp.original.state.undetermined && tmp.original.state.undetermined === true) {
 							if(o[tmp.id] === undefined && tmp.id !== $.jstree.root) {


### PR DESCRIPTION
When calculating undetermined state,   get_node() sometimes return a `false`, and get a "Cannot read property 'loaded' of undefined" exception.