### PR TITLE
point to min in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "jQuery tree plugin",
   "version": "3.3.3",
   "homepage": "http://jstree.com",
-  "main": "./dist/jstree.js",
+  "main": "./dist/jstree.min.js",
   "author": {
     "name": "Ivan Bozhanov",
     "email": "jstree@jstree.com",


### PR DESCRIPTION
Would you please point to the minified build so that the package is smaller when importing it?