### PR TITLE
Performance improvement when creating nodes

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2495,7 +2495,19 @@
 				node.appendChild(k);
 			}
 			if(old) {
-				node.appendChild(old);
+				k = d.createElement('UL');
+  				k.setAttribute('role', 'group');
+				k.className = 'jstree-children';
+                		for(i = 0, j = obj.children.length; i < j; i++) {
+					var cEl = obj.children[i];
+					var oEl = old.children[cEl];
+					if (!oEl) {
+						k.appendChild(this.redraw_node(cEl, true, true));
+					} else {
+						k.appendChild(oEl);
+					}
+				}
+				node.appendChild(k);
 			}
 			if(!is_callback) {
 				// append back using par / ind
@@ -3788,8 +3800,8 @@
 			}
 			tmp[pos] = node.id;
 			par.children = tmp;
-
-			this.redraw_node(par, true);
+			this.sort && this.sort(par, false);
+			this.redraw_node(par, false);
 			/**
 			 * triggered when a node is created
 			 * @event

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2495,26 +2495,31 @@
 				node.appendChild(k);
 			}
 			if(old) {
-				k = d.createElement('UL');
-  				k.setAttribute('role', 'group');
-				k.className = 'jstree-children';
-				var cs = old.children;
-				if (!cs) { // IE8 support
-					cs = {};
-					for(i = 0, j = obj.childNodes.length; i < j; i++) {
-						cs[obj.childNodes[i].id] = obj.childNodes[i];
-					}
+				var oldChildren = {};
+				var currentChildren = {};
+				for(i = 0, j = obj.children.length, k = old.childNodes.length; i < j || i < k; i++) {
+					old.childNodes[i] && (oldChildren[old.childNodes[i].id] = old.childNodes[i]);
+					obj.children[i] && (currentChildren[obj.children[i]] = true);
 				}
-                		for(i = 0, j = obj.children.length; i < j; i++) {
+				for(i = 0, j = obj.children.length, k = old.childNodes.length; i < j || i < k; i++) {
 					var cEl = obj.children[i];
-					var oEl = cs[cEl];
-					if (!oEl) { // If the element don't exists, create it
-						k.appendChild(this.redraw_node(cEl, true, true));
-					} else {
-						k.appendChild(oEl);
+					var oEl = old.childNodes[i];
+					if (cEl != (oEl && oEl.id)) {
+						if (oEl && (!cEl || !currentChildren[oEl.id])) {
+							old.removeChild(oEl);
+							i--;
+						} else {
+							var cNext = old.childNodes[i+1];
+							var el = oldChildren[cEl];
+							if (!el) {
+								old.insertBefore(this.redraw_node(cEl, true, true), cNext);
+							} else {
+								old.insertBefore(el, cNext);
+							}
+						}
 					}
 				}
-				node.appendChild(k);
+				node.appendChild(old);
 			}
 			if(!is_callback) {
 				// append back using par / ind

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2498,10 +2498,17 @@
 				k = d.createElement('UL');
   				k.setAttribute('role', 'group');
 				k.className = 'jstree-children';
+				var cs = old.children;
+				if (!cs) { // IE8 support
+					cs = {};
+					for(i = 0, j = obj.childNodes.length; i < j; i++) {
+						cs[obj.childNodes[i].id] = obj.childNodes[i];
+					}
+				}
                 		for(i = 0, j = obj.children.length; i < j; i++) {
 					var cEl = obj.children[i];
-					var oEl = old.children[cEl];
-					if (!oEl) {
+					var oEl = cs[cEl];
+					if (!oEl) { // If the element don't exists, create it
 						k.appendChild(this.redraw_node(cEl, true, true));
 					} else {
 						k.appendChild(oEl);

--- a/src/jstree.sort.js
+++ b/src/jstree.sort.js
@@ -37,13 +37,13 @@
 				.on("model.jstree", $.proxy(function (e, data) {
 						this.sort(data.parent, true);
 					}, this))
-				.on("rename_node.jstree create_node.jstree", $.proxy(function (e, data) {
+				.on("rename_node.jstree", $.proxy(function (e, data) {
 						this.sort(data.parent || data.node.parent, false);
-						this.redraw_node(data.parent || data.node.parent, true);
+						this.redraw_node(data.parent || data.node.parent, false);
 					}, this))
 				.on("move_node.jstree copy_node.jstree", $.proxy(function (e, data) {
 						this.sort(data.parent, false);
-						this.redraw_node(data.parent, true);
+						this.redraw_node(data.parent, false);
 					}, this));
 		};
 		/**


### PR DESCRIPTION
This patch will make the tree to be redrawn only one time when sorting is enabled and also will only create new nodes if needed, as addressed in https://github.com/vakata/jstree/issues/1406