### PR TITLE
Space instead of Ctrl+Space for node selection

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -642,11 +642,9 @@
 							else if(e.which === 39) { e.which = 37; }
 						}
 						switch(e.which) {
-							case 32: // aria defines space only with Ctrl
-								if(e.ctrlKey) {
-									e.type = "click";
-									$(e.currentTarget).trigger(e);
-								}
+							case 32: // space
+								e.type = "click";
+								$(e.currentTarget).trigger(e);
 								break;
 							case 13: // enter
 								e.type = "click";


### PR DESCRIPTION
https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard-interaction-18

Selection in multi-select trees: Authors may implement either of two interaction models to support multiple selection: a recommended model that does not require the user to hold a modifier key, such as Shift or Control, while navigating the list or an alternative model that does require modifier keys to be held while navigating in order to avoid losing selection states.
**Recommended selection model -- holding a modifier key while moving focus is not necessary:
Space: Toggles the selection state of the focused node.**
Shift + Down Arrow (Optional): Moves focus to and toggles the selection state of the next node.
Shift + Up Arrow (Optional): Moves focus to and toggles the selection state of the previous node.
Shift + Space (Optional): Selects contiguous nodes from the last selected node to the current node.
Control + Shift + Home (Optional): Selects the node with focus and all nodes up to the first node.
Control + Shift + End (Optional): Selects the node with focus and all nodes down to the last node.
Control + A (Optional): Selects all nodes in the tree. Optionally, if all nodes are selected, it can also unselect all nodes.
Alternative selection model -- Moving focus without holding the Shift or Control modifier unselects all selected nodes except for the focused node:
Shift + Down Arrow: Moves focus to and toggles the selection state of the next node.
Shift + Up Arrow: Moves focus to and toggles the selection state of the previous node.
Control + Down Arrow: Without changing the selection state, moves focus to the next node.
Control + Up Arrow: Without changing the selection state, moves focus to the previous node.
Control + Space: Toggles the selection state of the focused node.
Shift + Space (Optional): Selects contiguous nodes from the most recently selected node to the current node.
Control + Shift + Home (Optional): Selects the node with focus and all nodes up to the first node.
Control + Shift + End (Optional): Selects the node with focus and all nodes down to the last node.
Control + A (Optional): Selects all nodes in the tree. Optionally, if all nodes are selected, it can also unselect all nodes.