### PR TITLE
 node changed correction

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1453,7 +1453,7 @@
 		 */
 		_node_changed : function (obj) {
 			obj = this.get_node(obj);
-			if(obj) {
+      if (obj && $.inArray(obj.id, this._model.changed)===-1) {
 				this._model.changed.push(obj.id);
 			}
 		},

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1453,7 +1453,7 @@
 		 */
 		_node_changed : function (obj) {
 			obj = this.get_node(obj);
-			if(obj) {
+      if (obj && $.inArray(obj.id, this._model.changed) === -1) {
 				this._model.changed.push(obj.id);
 			}
 		},

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1453,7 +1453,7 @@
 		 */
 		_node_changed : function (obj) {
 			obj = this.get_node(obj);
-      if (obj && $.inArray(obj.id, this._model.changed)===-1) {
+			if(obj) {
 				this._model.changed.push(obj.id);
 			}
 		},


### PR DESCRIPTION
I found out somtimes _node_changed pushes the objects to often into the changed array.
This is the case when you need to hide several nodes at once which share the same parent.
So this litte change will prevent a multiple redraw.