### PR TITLE
Fix multi-move glitch

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3989,7 +3989,7 @@
 					//obj = obj.slice();
 					for(t1 = 0, t2 = obj.length; t1 < t2; t1++) {
 						if((tmp = this.move_node(obj[t1], par, pos, callback, is_loaded, false, origin))) {
-							par = tmp;
+							//par = tmp; //Is this what you want in multi-move?
 							pos = "after";
 						}
 					}


### PR DESCRIPTION
Commented out a line in recursive move_node call that causes a group of moved nodes to become nested within each other. This doesn't seem to be present in the the minified version.