### PR TITLE
Fix error in checkbox plugin when three_state is disabled

### DIFF
--- a/src/jstree.checkbox.js
+++ b/src/jstree.checkbox.js
@@ -88,6 +88,7 @@
 			parent.bind.call(this);
 			this._data.checkbox.uto = false;
 			this._data.checkbox.selected = [];
+			this.settings.checkbox.cascade = '';
 			if(this.settings.checkbox.three_state) {
 				this.settings.checkbox.cascade = 'up+down+undetermined';
 			}


### PR DESCRIPTION
On line 108, the cascade property is accessed, but if three_state is disabled, then it is never set and jstree errors out. This fix sets the cascade value to an empty string so no error occurs.

