### PR TITLE
Option deselect_other_nodes for checkbox plugin

### DIFF
--- a/src/jstree.checkbox.js
+++ b/src/jstree.checkbox.js
@@ -81,7 +81,14 @@
 		 * @name $.jstree.defaults.checkbox.cascade_to_hidden
 		 * @plugin checkbox
 		 */
-		cascade_to_hidden : true
+		cascade_to_hidden : true,
+		
+		/**
+		 * This setting controls if all nodes other than that was clicked should be deselected when whole_node is set to false
+		 * @name $.jstree.defaults.checkbox.deselect_other_nodes
+		 * @plugin checkbox
+		 */
+		deselect_other_nodes : true
 	};
 	$.jstree.plugins.checkbox = function (options, parent) {
 		this.bind = function () {

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -3111,7 +3111,9 @@
 					this.deselect_node(obj, false, e);
 				}
 				else {
-					this.deselect_all(true);
+					if(this.settings.checkbox.deselect_other_nodes) {
+					   this.deselect_all(true);
+					}
 					this.select_node(obj, false, false, e);
 					this._data.core.last_clicked = this.get_node(obj);
 				}


### PR DESCRIPTION
It would be great to have a possibility to disable deselecting all other options while whole_node is set to false in a checkbox plugin. 
I have links at my nodes and I would like to be able to open a link, keeping all my checked nodes including the node, whose link I clicked.