### PR TITLE
Skip preventDefault for ctrl-click

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -753,7 +753,9 @@
 						}
 					}, this))
 				.on("click.jstree", ".jstree-anchor", $.proxy(function (e) {
-						e.preventDefault();
+						if(!(e.ctrlKey && e.which === 1)) { // skip prevent default if ctrl+left click
+					   		e.preventDefault();
+					   	}
 						if(e.currentTarget !== document.activeElement) { $(e.currentTarget).focus(); }
 						this.activate_node(e.currentTarget, e);
 					}, this))


### PR DESCRIPTION
Hello, thanks for the and great library, I use it regularly, and it's the best JS tree I've used.

There is an issue with the tree where you cannot ctrl+click on a node in the tree to open in new browser tabs. This is of course if you override the anchors to have href attributes.

You can observe this in any demo pages where ctrl+click will not work, but middleclick will, which opens in a new browser tab.

Please let me know if you want additions to documentation or any changes, or if I need to sign a contributors agreement. Regardless, I release ownership and copyright of this commit to @vakata.
