### PR TITLE
changed @media (max-width: 768px) from 768px to 767.98px

### DIFF
--- a/dist/themes/default-dark/style.css
+++ b/dist/themes/default-dark/style.css
@@ -925,7 +925,7 @@
 .jstree-default-dark-large.jstree-rtl .jstree-last {
   background: transparent;
 }
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
   #jstree-dnd.jstree-dnd-responsive {
     line-height: 40px;
     font-weight: bold;
@@ -954,7 +954,7 @@
     margin-top: -10px;
   }
 }
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
   .jstree-default-dark-responsive {
     /*
 	.jstree-open > .jstree-ocl,

--- a/dist/themes/default/style.css
+++ b/dist/themes/default/style.css
@@ -925,7 +925,7 @@
 .jstree-default-large.jstree-rtl .jstree-last {
   background: transparent;
 }
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
   #jstree-dnd.jstree-dnd-responsive {
     line-height: 40px;
     font-weight: bold;
@@ -954,7 +954,7 @@
     margin-top: -10px;
   }
 }
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
   .jstree-default-responsive {
     /*
 	.jstree-open > .jstree-ocl,

--- a/src/themes/default-dark/style.css
+++ b/src/themes/default-dark/style.css
@@ -925,7 +925,7 @@
 .jstree-default-dark-large.jstree-rtl .jstree-last {
   background: transparent;
 }
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
   #jstree-dnd.jstree-dnd-responsive {
     line-height: 40px;
     font-weight: bold;
@@ -954,7 +954,7 @@
     margin-top: -10px;
   }
 }
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
   .jstree-default-dark-responsive {
     /*
 	.jstree-open > .jstree-ocl,

--- a/src/themes/default/style.css
+++ b/src/themes/default/style.css
@@ -925,7 +925,7 @@
 .jstree-default-large.jstree-rtl .jstree-last {
   background: transparent;
 }
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
   #jstree-dnd.jstree-dnd-responsive {
     line-height: 40px;
     font-weight: bold;
@@ -954,7 +954,7 @@
     margin-top: -10px;
   }
 }
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
   .jstree-default-responsive {
     /*
 	.jstree-open > .jstree-ocl,

--- a/src/themes/main.less
+++ b/src/themes/main.less
@@ -57,7 +57,7 @@
 }
 
 // mobile theme attempt
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
 	#jstree-dnd.jstree-dnd-responsive when (@responsive = true) {
 		line-height:@base-height; font-weight:bold; font-size:1.1em; text-shadow:1px 1px white;
 		> i { background:transparent; width:@base-height; height:@base-height; }

--- a/src/themes/responsive.less
+++ b/src/themes/responsive.less
@@ -1,4 +1,4 @@
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
 	// background image
 	.jstree-icon { background-image:url("@{image-path}@{base-height}.png"); }
 


### PR DESCRIPTION
some devices like ipad and tablets are exactly 768px width and you don't want to hit this threshold.

It's recommended to be a bit below this threshold.

For example, bootstrap recommendation:
```
// Extra small devices (portrait phones, less than 576px)
@media (max-width: 575.98px) { ... }

// Small devices (landscape phones, less than 768px)
@media (max-width: 767.98px) { ... }

// Medium devices (tablets, less than 992px)
@media (max-width: 991.98px) { ... }

// Large devices (desktops, less than 1200px)
@media (max-width: 1199.98px) { ... }

// Extra large devices (large desktops)
// No media query since the extra-large breakpoint has no upper bound on its width
```

Taken from https://getbootstrap.com/docs/4.3/layout/overview/#responsive-breakpoints