### PR TITLE
Removed unused var in massload

### DIFF
--- a/src/jstree.massload.js
+++ b/src/jstree.massload.js
@@ -45,8 +45,7 @@
 			parent.init.call(this, el, options);
 		};
 		this._load_nodes = function (nodes, callback, is_callback, force_reload) {
-			var s = this.settings.massload,
-				nodesString = JSON.stringify(nodes),
+			var s = this.settings.massload,				
 				toLoad = [],
 				m = this._model.data,
 				i, j, dom;


### PR DESCRIPTION
var `nodesString = JSON.stringify(nodes)` is never used, but does some intense work on many nodes.