### PR TITLE
Fix oversize icons

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2565,7 +2565,7 @@
 				else {
 					node.childNodes[1].childNodes[0].style.backgroundImage = 'url("'+obj.icon+'")';
 					node.childNodes[1].childNodes[0].style.backgroundPosition = 'center center';
-					node.childNodes[1].childNodes[0].style.backgroundSize = 'auto';
+					node.childNodes[1].childNodes[0].style.backgroundSize = 'cover';
 					node.childNodes[1].childNodes[0].className += ' jstree-themeicon-custom';
 				}
 			}


### PR DESCRIPTION
If icon images are larger than the available icon space, the icon will not be correctly resized, and will have the edges cut off.