### PR TITLE
Speedup shift select drastically

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1056,8 +1056,8 @@
 					return false;
 				}
 
-				if(as_dom) {
-					obj = obj.id === $.jstree.root ? this.element : $('#' + obj.id.replace($.jstree.idregex,'\\$&'), this.element);
+			        if(as_dom) {
+					obj = obj.id === $.jstree.root ? this.element : $('#'+obj.id.replace($.jstree.idregex,'\\$&'));
 				}
 				return obj;
 			} catch (ex) { return false; }

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1057,7 +1057,7 @@
 				}
 
 			        if(as_dom) {
-					obj = obj.id === $.jstree.root ? this.element : $(this.element[0].querySelector('#'+obj.id.replace($.jstree.idregex,'\\$&')));
+					obj = obj.id === $.jstree.root ? this.element : $(this.element[0].querySelector("[id='"+obj.id+"']"));
 				}
 				return obj;
 			} catch (ex) { return false; }

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1057,7 +1057,7 @@
 				}
 
 			        if(as_dom) {
-					obj = obj.id === $.jstree.root ? this.element : $('#'+obj.id.replace($.jstree.idregex,'\\$&'));
+					obj = obj.id === $.jstree.root ? this.element : $(this.element[0].querySelector('#'+obj.id.replace($.jstree.idregex,'\\$&')));
 				}
 				return obj;
 			} catch (ex) { return false; }


### PR DESCRIPTION
When there are 10,000 nodes and a user selects one node then shift selects many nodes. The operation can take minutes, these changes optimises the query to use document.getElementById() internally through jQuery. The previous version actually caused a recursive query.