### PR TITLE
#2342 fix for DnD stop events triggered by non-jsTree origins

### DIFF
--- a/src/jstree.dnd.js
+++ b/src/jstree.dnd.js
@@ -459,6 +459,7 @@
 					scroll_i: false,
 					is_touch: false
 				};
+				elm = null;
 				$(document).off("mousemove.vakata.jstree touchmove.vakata.jstree", $.vakata.dnd.drag);
 				$(document).off("mouseup.vakata.jstree touchend.vakata.jstree", $.vakata.dnd.stop);
 			},


### PR DESCRIPTION
Not sure, but maybe `drg` var should also be nullified.