### PR TITLE
[Accessibility improvement] Add ability to explicitly set treeitems number and position

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -454,6 +454,12 @@
 		 */
 		restore_focus : true,
 		/**
+		 * Force to compute and set "aria-setsize" and "aria-posinset" explicitly for each treeitem. 
+		 * Some browsers may compute incorrect elements position and produce wrong announcements for screen readers. Defaults to `false`
+		 * @name $.jstree.defaults.core.compute_elements_positions
+		 */
+		compute_elements_positions : true,
+		/**
 		 * Default keyboard shortcuts (an object where each key is the button name or combo - like 'enter', 'ctrl-space', 'p', etc and the value is the function to execute in the instance's scope)
 		 * @name $.jstree.defaults.core.keyboard
 		 */
@@ -2499,6 +2505,10 @@
 			}
 			node.childNodes[1].setAttribute('aria-selected', !!obj.state.selected);
 			node.childNodes[1].setAttribute('aria-level', obj.parents.length);
+			if(this.settings.core.compute_elements_positions) {
+				node.childNodes[1].setAttribute('aria-setsize', m[obj.parent].children.length);
+				node.childNodes[1].setAttribute('aria-posinset', m[obj.parent].children.indexOf(obj.id) + 1);
+			}			
 			node.setAttribute('aria-labelledby', obj.a_attr.id);
 			if(obj.state.disabled) {
 				node.childNodes[1].setAttribute('aria-disabled', true);

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -458,7 +458,7 @@
 		 * Some browsers may compute incorrect elements position and produce wrong announcements for screen readers. Defaults to `false`
 		 * @name $.jstree.defaults.core.compute_elements_positions
 		 */
-		compute_elements_positions : true,
+		compute_elements_positions : false,
 		/**
 		 * Default keyboard shortcuts (an object where each key is the button name or combo - like 'enter', 'ctrl-space', 'p', etc and the value is the function to execute in the instance's scope)
 		 * @name $.jstree.defaults.core.keyboard


### PR DESCRIPTION
Aria-posinset and aria-setsize attributes is used by screen readers to define and announce tree element position and elements number. By default, these attributes are computed by the browser. And ARIA 1.1 says for them “If all items in a set are present in the document structure, it is not necessary to set this property, as the user agent can automatically calculate the set size and position for each item”.

But different browsers compute these properties differently. And for different combinations of screen readers and browsers -problems with elements position announcement can be appeared. Such problems are described in scope of https://github.com/vakata/jstree/issues/2448.

To fix them new option "compute_elements_positions" was introduced:

> Force to compute and set "aria-setsize" and "aria-posinset" explicitly for each treeitem. Some browsers may compute incorrect elements position and produce wrong announcements for screen readers. Defaults to `false` 

If user wants to increase compatibility for more browsers and screen readers combination, he can turn on this option. It will explicitly compute values of aria-posinset and aria-setsize attributes inside jsTree and set them for tree items. Different browsers and screen readers works more stable if we set these attributes explicitly.