### PR TITLE
Replace deprecated jquery trim with a new internal trim function

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -43,11 +43,8 @@
 		ccp_inst = false,
 		themes_loaded = [],
 		src = $('script:last').attr('src'),
+		rtrim = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,
 		document = window.document; // local variable is always faster to access then a global
-		trim_opts = {
-			trim_left: (/\S/).test("\xA0") ? /^[\s\xA0]+/ : /^\s+/,
-			trim_right: (/\S/).test("\xA0") ? /[\s\xA0]+$/ : /\s+$/
-		};
 
 	var setImmediate = window.setImmediate;
 	var Promise = window.Promise;
@@ -4971,7 +4968,7 @@
 		return text == null ? "" : String.prototype.trim.call(text);
 	} :
 	function (text) {
-		return text == null ? "" : text.toString().replace(trim_opts.trim_left, "").replace(trim_opts.trim_right, "");
+		return text == null ? "" : (text + "").replace(rtrim, "");
 	});
 }
 }));

--- a/src/jstree.js
+++ b/src/jstree.js
@@ -44,6 +44,10 @@
 		themes_loaded = [],
 		src = $('script:last').attr('src'),
 		document = window.document; // local variable is always faster to access then a global
+		trim_opts = {
+			trim_left: (/\S/).test("\xA0") ? /^[\s\xA0]+/ : /^\s+/,
+			trim_right: (/\S/).test("\xA0") ? /[\s\xA0]+$/ : /\s+$/
+		};
 
 	var setImmediate = window.setImmediate;
 	var Promise = window.Promise;
@@ -2053,7 +2057,7 @@
 			}
 			tmp = $.vakata.attributes(d, true);
 			$.each(tmp, function (i, v) {
-				v = $.trim(v);
+				v = $.vakata.trim(v);
 				if(!v.length) { return true; }
 				data.li_attr[i] = v;
 				if(i === 'id') {
@@ -2064,7 +2068,7 @@
 			if(tmp.length) {
 				tmp = $.vakata.attributes(tmp, true);
 				$.each(tmp, function (i, v) {
-					v = $.trim(v);
+					v = $.vakata.trim(v);
 					if(v.length) {
 						data.a_attr[i] = v;
 					}
@@ -4919,7 +4923,7 @@
 		if(node && node.attributes) {
 			$.each(node.attributes, function (i, v) {
 				if($.inArray(v.name.toLowerCase(),['style','contenteditable','hasfocus','tabindex']) !== -1) { return; }
-				if(v.value !== null && $.trim(v.value) !== '') {
+				if(v.value !== null && $.vakata.trim(v.value) !== '') {
 					if(with_values) { attr[v.name] = v.value; }
 					else { attr.push(v.name); }
 				}
@@ -4963,4 +4967,11 @@
 		}
 		return d;
 	};
+	$.vakata.trim = (String.prototype.trim ? function(text) {
+		return text == null ? "" : String.prototype.trim.call(text);
+	} :
+	function (text) {
+		return text == null ? "" : text.toString().replace(trim_opts.trim_left, "").replace(trim_opts.trim_right, "");
+	});
+}
 }));

--- a/src/jstree.search.js
+++ b/src/jstree.search.js
@@ -136,7 +136,7 @@
 		 * @trigger search.jstree
 		 */
 		this.search = function (str, skip_async, show_only_matches, inside, append, show_only_matches_children) {
-			if(str === false || $.trim(str.toString()) === "") {
+			if(str === false || $.vakata.trim(str.toString()) === "") {
 				return this.clear_search();
 			}
 			inside = this.get_node(inside);


### PR DESCRIPTION
These changes were made due to the deprecation of the trim function on jQuery 3.5. To have similar behaviour and functionality that also supports older browsers like Internet Explorer 6-8, Opera 12.1x, and Safari 5.1+, the newly internal trim function is partly adapted from the jQuery trim originated from version 1.12.