### PR TITLE
[Accessibility] Additional fix for #2431. Remove unnecessary accessible label from li attribute

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -2508,8 +2508,7 @@
 			if(this.settings.core.compute_elements_positions) {
 				node.childNodes[1].setAttribute('aria-setsize', m[obj.parent].children.length);
 				node.childNodes[1].setAttribute('aria-posinset', m[obj.parent].children.indexOf(obj.id) + 1);
-			}			
-			node.setAttribute('aria-labelledby', obj.a_attr.id);
+			}
 			if(obj.state.disabled) {
 				node.childNodes[1].setAttribute('aria-disabled', true);
 			}


### PR DESCRIPTION
It's additional fix for https://github.com/vakata/jstree/issues/2431.
As `<li>` element has role='none' it should be hidden from assistive technologies. But this element still has accessible label (aria-labelldby) attribute.
Some assistive technologies might ignore role='none' if element has accesible name. In some cases this can cause unwanted behavior, for example:

- Latest version of axe-core 4.1.0 - reports missing children.
- Mozilla firefox exposes incorrect element position to screen reader.

To fix this aria-labelldby attribute cold be removed from `<li>` element to not confuse assistive technologies. `<Li>` element should be hideen from assistive technologies and no need any aria attrbutes. Our focusable element is `<a>` and accessible name is already exposed by this element.