### PR TITLE
fixed memory leak in context menu plugin: issue 2234

### DIFF
--- a/src/jstree.contextmenu.js
+++ b/src/jstree.contextmenu.js
@@ -250,6 +250,7 @@
 			if(this._data.contextmenu.visible) {
 				$.vakata.context.hide();
 			}
+			$(document).off("context_hide.vakata.jstree");
 			parent.teardown.call(this);
 		};
 


### PR DESCRIPTION
This pull request fixes issue https://github.com/vakata/jstree/issues/2234
Removed listener when context menu plugin is torn down 