### PR TITLE
[Accessibility]Move aria-busy state to anchor element to fix #2540

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1276,7 +1276,7 @@
 		 * @trigger load_node.jstree
 		 */
 		load_node : function (obj, callback) {
-			var k, l, i, j, c;
+			var dom = this.get_node(obj, true), k, l, i, j, c;
 			if($.vakata.is_array(obj)) {
 				this._load_nodes(obj.slice(), callback);
 				return true;
@@ -1313,7 +1313,12 @@
 			}
 			obj.state.failed = false;
 			obj.state.loading = true;
-			this.get_node(obj, true).addClass("jstree-loading").attr('aria-busy',true);
+			if (obj.a_attr) {
+				dom.children(".jstree-anchor").attr('aria-busy', true);
+			} else {
+				dom.attr('aria-busy', true);
+			}
+			dom.addClass("jstree-loading");
 			this._load_node(obj, function (status) {
 				obj = this._model.data[obj.id];
 				obj.state.loading = false;
@@ -1337,7 +1342,12 @@
 						}
 					}
 				}
-				dom.removeClass("jstree-loading").attr('aria-busy',false);
+				if (obj.a_attr) {
+					dom.children(".jstree-anchor").attr('aria-busy', false);
+				} else {
+					dom.attr('aria-busy', false);
+				}
+				dom.removeClass("jstree-loading");
 				/**
 				 * triggered after a node is loaded
 				 * @event


### PR DESCRIPTION
Previosly aria-busy state, that was triggered by node loading, was set on li element which use role="none". According to specifications elements with role="none" shouldn't use any aria attributes. Hence such behavior triggered AXE error described in #2540. 

So to avoid this issue aria-busy state will be moved to the anchor element as this element is focusable in current implementation.
As the load_node method is used to set loading state for both tree container and tree nodes. So we need to check if current element is node and then set aria-busy on its anchor element. If the current element is tree container the code will work as previously and will set  aria-busy on the container.

In addition, while working on this case i noticed that setting of loading state works fine for tree container but doesn't properly works for nodes.

Second part of code where we removing 'jstree-loading' class and set aria-busy="false" works fine for both cases.

But the first part where we adding 'jstree-loading' class and set aria-busy="true" doesnt take effect on nodes(Hence loading spinner is never shown). This code only works with tree container. This behavior is observed befor and after my proposed changes.

@vakata could you advice how we could properly set loading class and aria-busy for node to make it works? Or maybe it could be my local problem?
