### PR TITLE
Fix 'scrollable-region-focusable' AXE error to fix #2541

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -910,6 +910,7 @@
 						this._data.core.focused = null;
 						$(e.currentTarget).filter('.jstree-hovered').trigger('mouseleave');
 						this.element.attr('tabindex', '0');
+						$(e.currentTarget).attr('tabindex', '-1');
 					}.bind(this))
 				.on('focus.jstree', '.jstree-anchor', function (e) {
 						var tmp = this.get_node(e.currentTarget);
@@ -919,6 +920,7 @@
 						this.element.find('.jstree-hovered').not(e.currentTarget).trigger('mouseleave');
 						$(e.currentTarget).trigger('mouseenter');
 						this.element.attr('tabindex', '-1');
+						$(e.currentTarget).attr('tabindex', '0');
 					}.bind(this))
 				.on('focus.jstree', function () {
 						if(+(new Date()) - was_click > 500 && !this._data.core.focused && this.settings.core.restore_focus) {


### PR DESCRIPTION
Fixed 'scrollable-region-focusable' AXE error described in #2541

By default tabindex='0' is set for jstree container. When focus is set on tree element tabindex for jstree container is set as '-1' but currently focused element also use tabindex='-1'. This put us to situation when no elements with  tabindex='0' are in jstree and this case trigger AXE error and might cause potential problems with accessibility tools.

To avoid this issue  tabindex='0' could be set on the focused node to have at least one visible focusable element when focus is inside jstree..