### PR TITLE
Fix compatibility with Webpack

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1,7 +1,7 @@
-import TreeNode from "model/TreeNode";
-import Tree from "model/Tree";
-import InfiniteScroller from "render/InfiniteScroller";
-import Flat from "render/Flat";
+import TreeNode from "./model/TreeNode";
+import Tree from "./model/Tree";
+import InfiniteScroller from "./render/InfiniteScroller";
+import Flat from "./render/Flat";
 
 class jsTree
 {

--- a/src/model/Tree.js
+++ b/src/model/Tree.js
@@ -1,4 +1,4 @@
-import TreeNode from "TreeNode";
+import TreeNode from "./TreeNode";
 
 class Tree
 {


### PR DESCRIPTION
Webpack path resolution currently fails.

Prefixing paths by a `./` fixes this.

See https://webpack.js.org/concepts/module-resolution/#resolving-rules-in-webpack for more details about Webpack resolution rules.