### PR TITLE
Fallback when WebWorkers are available but deactivated - close #2606

### DIFF
--- a/src/jstree.js
+++ b/src/jstree.js
@@ -1988,6 +1988,15 @@
 								this._data.core.working = false;
 							}
 						}.bind(this);
+						w.onerror = function (e) {
+							rslt.call(this, func(args), false);
+							if(this._data.core.worker_queue.length) {
+								this._append_json_data.apply(this, this._data.core.worker_queue.shift());
+							}
+							else {
+								this._data.core.working = false;
+							}
+						}.bind(this);
 						if(!args.par) {
 							if(this._data.core.worker_queue.length) {
 								this._append_json_data.apply(this, this._data.core.worker_queue.shift());


### PR DESCRIPTION
Tested manually with [the demo](https://github.com/vakata/jstree/tree/master/demo/basic) with version 3.3.12: it works as expected (with the patch) even the WebWorkers are blocked by a browser extension like uMatrix.