### PR TITLE
DND: drop node on blank space in tree

### DIFF
--- a/src/jstree.dnd.js
+++ b/src/jstree.dnd.js
@@ -256,7 +256,7 @@
 						ref = ins.settings.dnd.large_drop_target ? $(data.event.target).closest('.jstree-node').children('.jstree-anchor') : $(data.event.target).closest('.jstree-anchor');
 						if (ins.settings.dnd.blank_space_drop && ref.length === 0) {
 							// if we are not hovering a tree node, but an empty space in tree, get last node
-							ref = ins.settings.customdnd.large_drop_target ? $(data.event.target).find('.jstree-node').children('.jstree-anchor').last() : $(data.event.target).find('.jstree-anchor').last();
+							ref = ins.settings.dnd.large_drop_target ? $(data.event.target).find('.jstree-node').children('.jstree-anchor').last() : $(data.event.target).find('.jstree-anchor').last();
 						}
 						
 						if(ref && ref.length && ref.parent().is('.jstree-closed, .jstree-open, .jstree-leaf')) {

--- a/src/jstree.dnd.js
+++ b/src/jstree.dnd.js
@@ -92,7 +92,13 @@
 		 * @name $.jstree.defaults.dnd.use_html5
 		 * @plugin dnd
 		 */
-		use_html5: false
+		use_html5: false,
+		/**
+		 * controls whether items can be dropped anywhere on the tree, not just on the node or anchor, by default only the node/anchor is a valid drop target. Works best with the wholerow plugin.
+		 * @name $.jstree.defaults.dnd.blank_space_drop
+		 * @plugin dnd
+		 */
+		blank_space_drop: false
 	};
 	var drg, elm;
 	// TODO: now check works by checking for each node individually, how about max_children, unique, etc?
@@ -248,6 +254,11 @@
 					else {
 						// if we are hovering a tree node
 						ref = ins.settings.dnd.large_drop_target ? $(data.event.target).closest('.jstree-node').children('.jstree-anchor') : $(data.event.target).closest('.jstree-anchor');
+						if (ins.settings.dnd.blank_space_drop && ref.length === 0) {
+							// if we are not hovering a tree node, but an empty space in tree, get last node
+							ref = ins.settings.customdnd.large_drop_target ? $(data.event.target).find('.jstree-node').children('.jstree-anchor').last() : $(data.event.target).find('.jstree-anchor').last();
+						}
+						
 						if(ref && ref.length && ref.parent().is('.jstree-closed, .jstree-open, .jstree-leaf')) {
 							off = ref.offset();
 							rel = (data.event.pageY !== undefined ? data.event.pageY : data.event.originalEvent.pageY) - off.top;

--- a/src/jstree.dnd.js
+++ b/src/jstree.dnd.js
@@ -235,7 +235,7 @@
 
 					// if are hovering the container itself add a new root node
 					//console.log(data.event);
-					if( (data.event.target === ins.element[0] || data.event.target === ins.get_container_ul()[0]) && ins.get_container_ul().children().length === 0) {
+					if( (data.event.target === ins.element[0] || data.event.target === ins.get_container_ul()[0]) && (ins.get_container_ul().children().length === 0 || ins.settings.dnd.blank_space_drop === 'root')) {
 						ok = true;
 						for(t1 = 0, t2 = data.data.nodes.length; t1 < t2; t1++) {
 							ok = ok && ins.check( (data.data.origin && (data.data.origin.settings.dnd.always_copy || (data.data.origin.settings.dnd.copy && (data.event.metaKey || data.event.ctrlKey)) ) ? "copy_node" : "move_node"), (data.data.origin && data.data.origin !== ins ? data.data.origin.get_node(data.data.nodes[t1]) : data.data.nodes[t1]), $.jstree.root, 'last', { 'dnd' : true, 'ref' : ins.get_node($.jstree.root), 'pos' : 'i', 'origin' : data.data.origin, 'is_multi' : (data.data.origin && data.data.origin !== ins), 'is_foreign' : (!data.data.origin) });
@@ -254,7 +254,7 @@
 					else {
 						// if we are hovering a tree node
 						ref = ins.settings.dnd.large_drop_target ? $(data.event.target).closest('.jstree-node').children('.jstree-anchor') : $(data.event.target).closest('.jstree-anchor');
-						if (ins.settings.dnd.blank_space_drop && ref.length === 0) {
+						if (ins.settings.dnd.blank_space_drop === true && ref.length === 0) {
 							// if we are not hovering a tree node, but an empty space in tree, get last node
 							ref = ins.settings.dnd.large_drop_target ? $(data.event.target).find('.jstree-node').children('.jstree-anchor').last() : $(data.event.target).find('.jstree-anchor').last();
 						}


### PR DESCRIPTION
Hi, quick edit to allow dropping nodes on blank space in tree as shown below:
![image](https://user-images.githubusercontent.com/56397164/194069085-5cb81e15-d258-4898-b470-d6521b783968.png)
seems to be working fine on mobile too:
![image](https://user-images.githubusercontent.com/56397164/194069221-765f6728-abcb-4a80-b871-a50103bd8b8c.png)
Configurable via settings, default false (as is before this PR)
